### PR TITLE
feat: add multiply function

### DIFF
--- a/scripts/config/msu/classes/weighted_container.nut
+++ b/scripts/config/msu/classes/weighted_container.nut
@@ -127,6 +127,16 @@
 		this.updateWeight(_item, _weight);
 	}
 
+	function multiply( _multipliers )
+	{
+		// _multipliers is an array of len 2 arrays with idx 0 being item and idx 1 being multiplier
+
+		foreach (multiplier in _multipliers)
+		{
+			if (this.contains(multiplier[1])) this.setWeight(multiplier[1], this.getWeight(multiplier[1]) * multiplier[0]);
+		}
+	}
+
 	function apply( _function )
 	{
 		// _function (_item, _weight)


### PR DESCRIPTION
This solves a particular thing in PTR where I have a list of multipliers for items in weighted containers and I want to multiply the weights. Currently, I have to do it via a custom helper function like following where I have to pass the container to the function. I think such a function being inside the container is helpful.
```squirrel
function applyMultipliers( _multipliersList, _treeContainer )
{
	foreach (multiplier in _multipliersList)
	{
		local tree = multiplier[1];
		if (_treeContainer.contains(tree)) _treeContainer.setWeight(tree, _treeContainer.getWeight(tree) * multiplier[0]);
	}
}
```