### PR TITLE
feat: add helpful log errors to type checking functions

### DIFF
--- a/scripts/config/msu/type_checkers.nut
+++ b/scripts/config/msu/type_checkers.nut
@@ -39,6 +39,7 @@
 	{
 		if (typeof value != "instance" || !(value instanceof _class))
 		{
+			::logError(format("%s must be an instance of the class %s.", value, _class));
 			throw ::MSU.Exception.InvalidType(value);
 		}
 	}
@@ -61,6 +62,7 @@
 	{
 		if (typeof value != _type)
 		{
+			::logError(format("%s must have the type: %s.", value, _type));
 			throw ::MSU.Exception.InvalidType(value);
 		}
 	}
@@ -72,6 +74,7 @@
 	{
 		if (_typeArray.find(typeof value) == null)
 		{
+			::logError(format("%s must have one of the types: %s.", value, _typeArray.reduce(@(a, b) format("%s, %s", a, b))));
 			throw ::MSU.Exception.InvalidType(value);
 		}
 	}
@@ -83,6 +86,7 @@
 	{
 		if (_typeArray.find(typeof value) != null)
 		{
+			::logError(format("%s must NOT be one of the types: %s.", value, _typeArray.reduce(@(a, b) format("%s, %s", a, b))));
 			throw ::MSU.Exception.InvalidType(value);
 		}
 	}

--- a/scripts/config/msu/type_checkers.nut
+++ b/scripts/config/msu/type_checkers.nut
@@ -39,7 +39,7 @@
 	{
 		if (typeof value != "instance" || !(value instanceof _class))
 		{
-			::logError(format("%s must be an instance of the class %s.", value, _class));
+			::logError(value + " must be an instance of the class: " + _class);
 			throw ::MSU.Exception.InvalidType(value);
 		}
 	}
@@ -62,7 +62,7 @@
 	{
 		if (typeof value != _type)
 		{
-			::logError(format("%s must have the type: %s.", value, _type));
+			::logError(value + " must have the type: " + _type);
 			throw ::MSU.Exception.InvalidType(value);
 		}
 	}
@@ -74,7 +74,7 @@
 	{
 		if (_typeArray.find(typeof value) == null)
 		{
-			::logError(format("%s must have one of the types: %s.", value, _typeArray.reduce(@(a, b) format("%s, %s", a, b))));
+			::logError(value + " must have one of the types: " + _typeArray.reduce(@(a, b) format("%s, %s", a, b)));
 			throw ::MSU.Exception.InvalidType(value);
 		}
 	}
@@ -86,7 +86,7 @@
 	{
 		if (_typeArray.find(typeof value) != null)
 		{
-			::logError(format("%s must NOT be one of the types: %s.", value, _typeArray.reduce(@(a, b) format("%s, %s", a, b))));
+			::logError(value + " must NOT have one of the types: " + _typeArray.reduce(@(a, b) format("%s, %s", a, b)));
 			throw ::MSU.Exception.InvalidType(value);
 		}
 	}


### PR DESCRIPTION
I believe using `format` here has a chance of failure because as we saw earlier in the `getInQuotes` function, format doesn't seem to roll nicely with stuff that can't be converted to string? So we should instead use string concatenation here, right?