### PR TITLE
feat: adds an enum class

### DIFF
--- a/scripts/config/msu/classes/enum.nut
+++ b/scripts/config/msu/classes/enum.nut
@@ -2,7 +2,6 @@
 {
 	__Keys = null;
 	__ValueKeyArray = null;
-	__NextICache = null;
 
 	constructor( _array = null )
 	{

--- a/scripts/config/msu/classes/enum.nut
+++ b/scripts/config/msu/classes/enum.nut
@@ -41,6 +41,12 @@
 		return this.__Keys.len();
 	}
 
+	function contains( _value )
+	{
+		::MSU.requireInt(_value);
+		return _value >= 0 && _value < this.len();
+	}
+
 	function _get( _key )
 	{
 		if (_key in this.__Keys) return this.__Keys[_key];

--- a/scripts/config/msu/classes/enum.nut
+++ b/scripts/config/msu/classes/enum.nut
@@ -1,29 +1,30 @@
 ::MSU.Class.Enum <- class
 {
-	_Keys = null;
-	_ValueKeyArray = null;
+	__Keys = null;
+	__ValueKeyArray = null;
+	__NextICache = null;
 
 	constructor( _array = null )
 	{
-		this._Keys = {};
-		this._ValueKeyArray = [];
+		this.__Keys = {};
+		this.__ValueKeyArray = [];
 		if (_array != null) this.addArray(_array);
 	}
 
-	function _isValidKey( _key )
+	function __isValidKey( _key )
 	{
 		return typeof _key == "string" && _key != "" && _key.slice(0,1).tolower() != _key.slice(0,1);
 	}
 
 	function add( _key )
 	{
-		if (!this._isValidKey(_key))
+		if (!this.__isValidKey(_key))
 		{
 			::logError("MSU Enum Keys must be non-empty strings and start with a capitalized letter");
 			throw ::MSU.Exception.InvalidValue(_key);
 		}
-		this._Keys[_key] <- this._Keys.len();
-		this._ValueKeyArray.push(_key);
+		this.__Keys[_key] <- this.__Keys.len();
+		this.__ValueKeyArray.push(_key);
 	}
 
 	function addArray( _array )
@@ -33,17 +34,17 @@
 
 	function getKeyForValue( _value )
 	{
-		return this._ValueKeyArray[_value];
+		return this.__ValueKeyArray[_value];
 	}
 
 	function len()
 	{
-		return this._Keys.len();
+		return this.__Keys.len();
 	}
 
 	function _get( _key )
 	{
-		if (_key in this._Keys) return this._Keys[_key];
+		if (_key in this.__Keys) return this.__Keys[_key];
 		throw null;
 	}
 }

--- a/scripts/config/msu/classes/enum.nut
+++ b/scripts/config/msu/classes/enum.nut
@@ -1,0 +1,49 @@
+::MSU.Class.Enum <- class
+{
+	_Keys = null;
+	_ValueKeyArray = null;
+
+	constructor( _array = null )
+	{
+		this._Keys = {};
+		this._ValueKeyArray = [];
+		if (_array != null) this.addArray(_array);
+	}
+
+	function _isValidKey( _key )
+	{
+		return typeof _key == "string" && _key != "" && _key.slice(0,1).tolower() != _key.slice(0,1);
+	}
+
+	function add( _key )
+	{
+		if (!this._isValidKey(_key))
+		{
+			::logError("MSU Enum Keys must be non-empty strings and start with a capitalized letter");
+			throw ::MSU.Exception.InvalidValue(_key);
+		}
+		this._Keys[_key] <- this._Keys.len();
+		this._ValueKeyArray.push(_key);
+	}
+
+	function addArray( _array )
+	{
+		foreach (value in _array) this.add(value);
+	}
+
+	function getKeyForValue( _value )
+	{
+		return this._ValueKeyArray[_value];
+	}
+
+	function len()
+	{
+		return this._Keys.len();
+	}
+
+	function _get( _key )
+	{
+		if (_key in this._Keys) return this._Keys[_key];
+		throw null;
+	}
+}

--- a/scripts/config/msu/classes/enum.nut
+++ b/scripts/config/msu/classes/enum.nut
@@ -47,4 +47,16 @@
 		if (_key in this.__Keys) return this.__Keys[_key];
 		throw null;
 	}
+
+	function _cloned( _original )
+	{
+		this.__Keys = _original.__Keys;
+		this.__ValueKeyArray = _original.__ValueKeyArray;
+	}
+
+	function _nexti( _prev )
+	{
+		if (_prev == null) return this.__ValueKeyArray[0];
+		return this.__Keys[_prev] < this.len() - 1 ? this.__ValueKeyArray[this.__Keys[_prev] + 1] : null;
+	}
 }


### PR DESCRIPTION
The goal here is to simplify the creation of an extensible enum.
Squirrel Enums are not extensible by design, and BB Enums don't have any of the convenience functions that would allow modders to easily add their own values (or any of the safety checks to make sure values are ordered).

Imo we might wanna add a second Enum Class that handles enums with arbitrary values that can be defined by the modder. I'd initially made it be just a toggle set during the instantiation, but that overcomplicated some of the aspects of the class. It also shouldn't be a child/parent class of this, but maybe they can both inherit from the same abstract ancestor. I think we can leave it for now and get to it at a later point.