### PR TITLE
fix(vanilla): skills not being added when a skill with the same ID which is garbage exists in SkillsToAdd

### DIFF
--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -28,7 +28,7 @@
 	}
 
 	// VANILLAFIX - http://battlebrothersgame.com/forums/topic/weapon-skills-lost-on-load-if-multiple-skills-call-unequip-and-equip-in-onadded/
-	// The fix works by temporarily changing the ID of the skill before calling the vanilla `add` function
+	// The fix works by temporarily changing the IDs of the garbage skills before calling the vanilla `add` function
 	local add = o.add;
 	o.add = function( _skill, _order = 0 )
 	{

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -32,20 +32,27 @@
 	local add = o.add;
 	o.add = function( _skill, _order = 0 )
 	{
-		local suffix = "";
+		local garbageSkills = {};
 		foreach (skill in this.m.SkillsToAdd)
 		{
 			if (skill.isGarbage() && skill.getID() == _skill.getID())
 			{
-				suffix = "" + _skill;
-				_skill.m.ID += suffix;
-				break;
+				local suffix = "" + skill;
+				skill.m.ID += suffix;
+				garbageSkills[skill] <- suffix;;
 			}
 		}
 
 		local ret = add(_skill, _order);
 
-		if (suffix != "") _skill.m.ID = _skill.m.ID.slice(0, -suffix.len());
+		if (garbageSkills.len() > 0)
+		{
+			foreach (skill, suffix in garbageSkills)
+			{
+				skill.m.ID = skill.m.ID.slice(0, -suffix.len());
+			}
+			garbageSkills.clear();
+		}
 
 		return ret;
 	}

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -27,6 +27,29 @@
 		this.m.ScheduledChangesSkills.clear();
 	}
 
+	// VANILLAFIX - http://battlebrothersgame.com/forums/topic/weapon-skills-lost-on-load-if-multiple-skills-call-unequip-and-equip-in-onadded/
+	// The fix works by temporarily changing the ID of the skill before calling the vanilla `add` function
+	local add = o.add;
+	o.add = function( _skill, _order = 0 )
+	{
+		local suffix = "";
+		foreach (skill in this.m.SkillsToAdd)
+		{
+			if (skill.isGarbage() && skill.getID() == _skill.getID())
+			{
+				suffix = "" + _skill;
+				_skill.m.ID += suffix;
+				break;
+			}
+		}
+
+		local ret = add(_skill, _order);
+
+		if (suffix != "") _skill.m.ID = _skill.m.ID.slice(0, -suffix.len());
+
+		return ret;
+	}
+
 	o.callSkillsFunction <- function( _function, _argsArray = null, _update = true, _aliveOnly = false )
 	{
 		if (_argsArray == null) _argsArray = [null];


### PR DESCRIPTION
I've tested the fix in PTR and it works. However, I think it will be more robust if we overwrite the vanilla `add` function and just add the `isGarbage` test as suggested in my vanilla bug report. This way we don't modify the skill ID and anything from a mod that may be checking for skill ids in `this.m.SkillsToAdd` won't get thrown off (although this is probably almost never going to happen).

EDIT: Check out the PR #206 as it has an implementation that accomplishes other things in addition to fixing this issue in different way.