### PR TITLE
feat: add ability to specify a base item whose values are used for the named item before randomizing

### DIFF
--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -1,0 +1,30 @@
+::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
+	q.m.BaseItemScript <- null;
+
+	q.getValuesForRandomize <- function()
+	{
+		if (this.m.BaseItemScript == null)
+			return {};
+
+		local baseItem = ::new(this.m.BaseItemScript);
+		return {
+			Condition = baseItem.m.Condition,
+			ConditionMax = baseItem.m.ConditionMax,
+			StaminaModifier = baseItem.m.StaminaModifier
+		};
+	}
+
+	q.setValuesBeforeRandomize <- function( _values )
+	{
+		foreach (key, value in _values)
+		{
+			this.m[key] = value;
+		}
+	}
+
+	q.randomizeValues = @(__original) function()
+	{
+		this.setValuesBeforeRandomize(this.getValuesForRandomize());
+		return __original();
+	}
+});

--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -1,9 +1,12 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/armor/named/named_armor");
 
 ::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
-	q.m.BaseItemFields = [
-		"Condition",
-		"ConditionMax",
-		"StaminaModifier"
-	];
+	q.getBaseItemFields = @() function()
+	{
+		return [
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier",
+		];
+	}
 });

--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -1,4 +1,6 @@
 ::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
+	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -9,6 +11,8 @@
 	}
 });
 
-::MSU.HooksMod.hookTree("scripts/items/armor/named/named_armor", function(q) {
-	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+::MSU.QueueBucket.VeryLate.push(function() {
+	::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
+		::MSU.HooksHelper.addBaseItemToNamedItemVeryLate(q);
+	});
 });

--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -1,6 +1,6 @@
-::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
-	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/armor/named/named_armor");
 
+::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -9,10 +9,4 @@
 			"StaminaModifier"
 		];
 	}
-});
-
-::MSU.QueueBucket.VeryLate.push(function() {
-	::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
-		::MSU.HooksHelper.addBaseItemToNamedItemVeryLate(q);
-	});
 });

--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -1,12 +1,9 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/armor/named/named_armor");
 
 ::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
-	q.getFieldsForRandomize <- function()
-	{
-		return [
-			"Condition",
-			"ConditionMax",
-			"StaminaModifier"
-		];
-	}
+	q.m.BaseItemFields = [
+		"Condition",
+		"ConditionMax",
+		"StaminaModifier"
+	];
 });

--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -1,6 +1,4 @@
 ::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
-	q.m.BaseItemScript <- null;
-
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -9,22 +7,8 @@
 			"StaminaModifier"
 		];
 	}
+});
 
-	q.setValuesBeforeRandomize <- function()
-	{
-		if (this.m.BaseItemScript == null)
-			return;
-
-		local baseM = ::new(this.m.BaseItemScript).m;
-		foreach (field in this.getFieldsForRandomize())
-		{
-			this.m[field] = baseM[field];
-		}
-	}
-
-	q.randomizeValues = @(__original) function()
-	{
-		this.setValuesBeforeRandomize();
-		return __original();
-	}
+::MSU.HooksMod.hookTree("scripts/items/armor/named/named_armor", function(q) {
+	::MSU.HooksHelper.addBaseItemToNamedItem(q);
 });

--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -1,6 +1,6 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/armor/named/named_armor");
 
-::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
+::MSU.MH.hook("scripts/items/armor/named/named_armor", function(q) {
 	q.getBaseItemFields = @() function()
 	{
 		return [

--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -4,9 +4,14 @@
 	q.getBaseItemFields = @() function()
 	{
 		return [
+			// The following fields are used in vanilla randomizeValues()
 			"Condition",
 			"ConditionMax",
 			"StaminaModifier",
+
+			// The following fields aren't used in vanilla randomizeValues() but we copy them
+			// for the sake of completion so that named items can be based on base items properly
+			// -- No such fields for this particular named item type --
 		];
 	}
 });

--- a/msu/hooks/items/armor/named/named_armor.nut
+++ b/msu/hooks/items/armor/named/named_armor.nut
@@ -1,30 +1,30 @@
 ::MSU.HooksMod.hook("scripts/items/armor/named/named_armor", function(q) {
 	q.m.BaseItemScript <- null;
 
-	q.getValuesForRandomize <- function()
+	q.getFieldsForRandomize <- function()
 	{
-		if (this.m.BaseItemScript == null)
-			return {};
-
-		local baseItem = ::new(this.m.BaseItemScript);
-		return {
-			Condition = baseItem.m.Condition,
-			ConditionMax = baseItem.m.ConditionMax,
-			StaminaModifier = baseItem.m.StaminaModifier
-		};
+		return [
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier"
+		];
 	}
 
-	q.setValuesBeforeRandomize <- function( _values )
+	q.setValuesBeforeRandomize <- function()
 	{
-		foreach (key, value in _values)
+		if (this.m.BaseItemScript == null)
+			return;
+
+		local baseM = ::new(this.m.BaseItemScript).m;
+		foreach (field in this.getFieldsForRandomize())
 		{
-			this.m[key] = value;
+			this.m[field] = baseM[field];
 		}
 	}
 
 	q.randomizeValues = @(__original) function()
 	{
-		this.setValuesBeforeRandomize(this.getValuesForRandomize());
+		this.setValuesBeforeRandomize();
 		return __original();
 	}
 });

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -1,0 +1,30 @@
+::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
+	q.m.BaseItemScript <- null;
+
+	q.getValuesForRandomize <- function()
+	{
+		if (this.m.BaseItemScript == null)
+			return {};
+
+		local baseItem = ::new(this.m.BaseItemScript);
+		return {
+			Condition = baseItem.m.Condition,
+			ConditionMax = baseItem.m.ConditionMax,
+			StaminaModifier = baseItem.m.StaminaModifier
+		};
+	}
+
+	q.setValuesBeforeRandomize <- function( _values )
+	{
+		foreach (key, value in _values)
+		{
+			this.m[key] = value;
+		}
+	}
+
+	q.randomizeValues = @(__original) function()
+	{
+		this.setValuesBeforeRandomize(this.getValuesForRandomize());
+		return __original();
+	}
+});

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -1,4 +1,6 @@
 ::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
+	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -9,6 +11,8 @@
 	}
 });
 
-::MSU.HooksMod.hookTree("scripts/items/helmets/named/named_helmet", function(q) {
-	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+::MSU.QueueBucket.VeryLate.push(function() {
+	::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
+		::MSU.HooksHelper.addBaseItemToNamedItemVeryLate(q);
+	});
 });

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -1,30 +1,30 @@
 ::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
 	q.m.BaseItemScript <- null;
 
-	q.getValuesForRandomize <- function()
+	q.getFieldsForRandomize <- function()
 	{
-		if (this.m.BaseItemScript == null)
-			return {};
-
-		local baseItem = ::new(this.m.BaseItemScript);
-		return {
-			Condition = baseItem.m.Condition,
-			ConditionMax = baseItem.m.ConditionMax,
-			StaminaModifier = baseItem.m.StaminaModifier
-		};
+		return [
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier"
+		];
 	}
 
-	q.setValuesBeforeRandomize <- function( _values )
+	q.setValuesBeforeRandomize <- function()
 	{
-		foreach (key, value in _values)
+		if (this.m.BaseItemScript == null)
+			return;
+
+		local baseM = ::new(this.m.BaseItemScript).m;
+		foreach (field in this.getFieldsForRandomize())
 		{
-			this.m[key] = value;
+			this.m[field] = baseM[field];
 		}
 	}
 
 	q.randomizeValues = @(__original) function()
 	{
-		this.setValuesBeforeRandomize(this.getValuesForRandomize());
+		this.setValuesBeforeRandomize();
 		return __original();
 	}
 });

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -1,6 +1,6 @@
-::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
-	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/helmets/named/named_helmet");
 
+::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -9,10 +9,4 @@
 			"StaminaModifier"
 		];
 	}
-});
-
-::MSU.QueueBucket.VeryLate.push(function() {
-	::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
-		::MSU.HooksHelper.addBaseItemToNamedItemVeryLate(q);
-	});
 });

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -1,9 +1,12 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/helmets/named/named_helmet");
 
 ::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
-	q.m.BaseItemFields = [
-		"Condition",
-		"ConditionMax",
-		"StaminaModifier"
-	];
+	q.getBaseItemFields = @() function()
+	{
+		return [
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier",
+		];
+	}
 });

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -1,6 +1,6 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/helmets/named/named_helmet");
 
-::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
+::MSU.MH.hook("scripts/items/helmets/named/named_helmet", function(q) {
 	q.getBaseItemFields = @() function()
 	{
 		return [

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -1,12 +1,9 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/helmets/named/named_helmet");
 
 ::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
-	q.getFieldsForRandomize <- function()
-	{
-		return [
-			"Condition",
-			"ConditionMax",
-			"StaminaModifier"
-		];
-	}
+	q.m.BaseItemFields = [
+		"Condition",
+		"ConditionMax",
+		"StaminaModifier"
+	];
 });

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -1,6 +1,4 @@
 ::MSU.HooksMod.hook("scripts/items/helmets/named/named_helmet", function(q) {
-	q.m.BaseItemScript <- null;
-
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -9,22 +7,8 @@
 			"StaminaModifier"
 		];
 	}
+});
 
-	q.setValuesBeforeRandomize <- function()
-	{
-		if (this.m.BaseItemScript == null)
-			return;
-
-		local baseM = ::new(this.m.BaseItemScript).m;
-		foreach (field in this.getFieldsForRandomize())
-		{
-			this.m[field] = baseM[field];
-		}
-	}
-
-	q.randomizeValues = @(__original) function()
-	{
-		this.setValuesBeforeRandomize();
-		return __original();
-	}
+::MSU.HooksMod.hookTree("scripts/items/helmets/named/named_helmet", function(q) {
+	::MSU.HooksHelper.addBaseItemToNamedItem(q);
 });

--- a/msu/hooks/items/helmets/named/named_helmet.nut
+++ b/msu/hooks/items/helmets/named/named_helmet.nut
@@ -4,9 +4,16 @@
 	q.getBaseItemFields = @() function()
 	{
 		return [
+			// The following fields are used in vanilla randomizeValues()
 			"Condition",
 			"ConditionMax",
 			"StaminaModifier",
+
+			// The following fields aren't used in vanilla randomizeValues() but we copy them
+			// for the sake of completion so that named items can be based on base items properly
+			"Armor", // This field is actually redundant and is unused in vanilla
+			"ArmorMax", // This field is actually redundant and is unused in vanilla
+			"Vision",
 		];
 	}
 });

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -1,0 +1,32 @@
+::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
+	q.m.BaseItemScript <- null;
+
+	q.getValuesForRandomize <- function()
+	{
+		if (this.m.BaseItemScript == null)
+			return {};
+
+		local baseItem = ::new(this.m.BaseItemScript);
+		return {
+			Condition = baseItem.m.Condition,
+			ConditionMax = baseItem.m.ConditionMax,
+			MeleeDefense = baseItem.m.MeleeDefense,
+			RangedDefense = baseItem.m.RangedDefense,
+			StaminaModifier = baseItem.m.StaminaModifier
+		};
+	}
+
+	q.setValuesBeforeRandomize <- function( _values )
+	{
+		foreach (key, value in _values)
+		{
+			this.m[key] = value;
+		}
+	}
+
+	q.randomizeValues = @(__original) function()
+	{
+		this.setValuesBeforeRandomize(this.getValuesForRandomize());
+		return __original();
+	}
+});

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -1,6 +1,6 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/shields/named/named_shield");
 
-::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
+::MSU.MH.hook("scripts/items/shields/named/named_shield", function(q) {
 	q.getBaseItemFields = @() function()
 	{
 		return [

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -1,4 +1,6 @@
 ::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
+	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -11,6 +13,8 @@
 	}
 });
 
-::MSU.HooksMod.hookTree("scripts/items/shields/named/named_shield", function(q) {
-	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+::MSU.QueueBucket.VeryLate.push(function() {
+	::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
+		::MSU.HooksHelper.addBaseItemToNamedItemVeryLate(q);
+	});
 });

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -1,32 +1,32 @@
 ::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
 	q.m.BaseItemScript <- null;
 
-	q.getValuesForRandomize <- function()
+	q.getFieldsForRandomize <- function()
 	{
-		if (this.m.BaseItemScript == null)
-			return {};
-
-		local baseItem = ::new(this.m.BaseItemScript);
-		return {
-			Condition = baseItem.m.Condition,
-			ConditionMax = baseItem.m.ConditionMax,
-			MeleeDefense = baseItem.m.MeleeDefense,
-			RangedDefense = baseItem.m.RangedDefense,
-			StaminaModifier = baseItem.m.StaminaModifier
-		};
+		return [
+			"Condition",
+			"ConditionMax",
+			"MeleeDefense",
+			"RangedDefense",
+			"StaminaModifier"
+		];
 	}
 
-	q.setValuesBeforeRandomize <- function( _values )
+	q.setValuesBeforeRandomize <- function()
 	{
-		foreach (key, value in _values)
+		if (this.m.BaseItemScript == null)
+			return;
+
+		local baseM = ::new(this.m.BaseItemScript).m;
+		foreach (field in this.getFieldsForRandomize())
 		{
-			this.m[key] = value;
+			this.m[field] = baseM[field];
 		}
 	}
 
 	q.randomizeValues = @(__original) function()
 	{
-		this.setValuesBeforeRandomize(this.getValuesForRandomize());
+		this.setValuesBeforeRandomize();
 		return __original();
 	}
 });

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -1,6 +1,4 @@
 ::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
-	q.m.BaseItemScript <- null;
-
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -11,22 +9,8 @@
 			"StaminaModifier"
 		];
 	}
+});
 
-	q.setValuesBeforeRandomize <- function()
-	{
-		if (this.m.BaseItemScript == null)
-			return;
-
-		local baseM = ::new(this.m.BaseItemScript).m;
-		foreach (field in this.getFieldsForRandomize())
-		{
-			this.m[field] = baseM[field];
-		}
-	}
-
-	q.randomizeValues = @(__original) function()
-	{
-		this.setValuesBeforeRandomize();
-		return __original();
-	}
+::MSU.HooksMod.hookTree("scripts/items/shields/named/named_shield", function(q) {
+	::MSU.HooksHelper.addBaseItemToNamedItem(q);
 });

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -1,6 +1,6 @@
-::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
-	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/shields/named/named_shield");
 
+::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -11,10 +11,4 @@
 			"StaminaModifier"
 		];
 	}
-});
-
-::MSU.QueueBucket.VeryLate.push(function() {
-	::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
-		::MSU.HooksHelper.addBaseItemToNamedItemVeryLate(q);
-	});
 });

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -4,11 +4,17 @@
 	q.getBaseItemFields = @() function()
 	{
 		return [
+			// The following fields are used in vanilla randomizeValues()
 			"Condition",
 			"ConditionMax",
 			"MeleeDefense",
 			"RangedDefense",
 			"StaminaModifier",
+			"FatigueOnSkillUse"
+
+			// The following fields aren't used in vanilla randomizeValues() but we copy them
+			// for the sake of completion so that named items can be based on base items properly
+			// -- No such fields for this particular named item type --
 		];
 	}
 });

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -1,11 +1,14 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/shields/named/named_shield");
 
 ::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
-	q.m.BaseItemFields = [
-		"Condition",
-		"ConditionMax",
-		"MeleeDefense",
-		"RangedDefense",
-		"StaminaModifier"
-	];
+	q.getBaseItemFields = @() function()
+	{
+		return [
+			"Condition",
+			"ConditionMax",
+			"MeleeDefense",
+			"RangedDefense",
+			"StaminaModifier",
+		];
+	}
 });

--- a/msu/hooks/items/shields/named/named_shield/named_shield.nut
+++ b/msu/hooks/items/shields/named/named_shield/named_shield.nut
@@ -1,14 +1,11 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/shields/named/named_shield");
 
 ::MSU.HooksMod.hook("scripts/items/shields/named/named_shield", function(q) {
-	q.getFieldsForRandomize <- function()
-	{
-		return [
-			"Condition",
-			"ConditionMax",
-			"MeleeDefense",
-			"RangedDefense",
-			"StaminaModifier"
-		];
-	}
+	q.m.BaseItemFields = [
+		"Condition",
+		"ConditionMax",
+		"MeleeDefense",
+		"RangedDefense",
+		"StaminaModifier"
+	];
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,0 +1,26 @@
+::mods_hookExactClass("items/weapons/named/named_weapon", function(o) {
+	o.m.BaseWeaponScript <- null;
+
+	local randomizeValues = o.randomizeValues;
+	o.randomizeValues <- function()
+	{
+		if (this.m.BaseWeaponScript != null)
+		{
+			local baseWeapon = ::new(this.m.BaseWeaponScript);
+			this.m.Condition = baseWeapon.m.Condition;
+			this.m.ConditionMax = baseWeapon.m.ConditionMax;
+			this.m.RegularDamage = baseWeapon.m.RegularDamage;
+			this.m.RegularDamageMax = baseWeapon.m.RegularDamageMax;
+			this.m.ArmorDamageMult = baseWeapon.m.ArmorDamageMult;
+			this.m.ChanceToHitHead = baseWeapon.m.ChanceToHitHead;
+			this.m.DirectDamageMult = baseWeapon.m.DirectDamageMult;
+			this.m.DirectDamageAdd = baseWeapon.m.DirectDamageAdd;
+			this.m.StaminaModifier = baseWeapon.m.StaminaModifier;
+			this.m.ShieldDamage = baseWeapon.m.ShieldDamage;
+			this.m.AdditionalAccuracy = baseWeapon.m.AdditionalAccuracy;
+			this.m.FatigueOnSkillUse = baseWeapon.m.FatigueOnSkillUse;
+		}
+
+		randomizeValues();
+	}
+});

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,8 +1,7 @@
 ::mods_hookExactClass("items/weapons/named/named_weapon", function(o) {
 	o.m.BaseWeaponScript <- null;
 
-	local randomizeValues = o.randomizeValues;
-	o.randomizeValues <- function()
+	o.setValuesFromBaseWeapon <- function()
 	{
 		if (this.m.BaseWeaponScript != null)
 		{
@@ -20,7 +19,12 @@
 			this.m.AdditionalAccuracy = baseWeapon.m.AdditionalAccuracy;
 			this.m.FatigueOnSkillUse = baseWeapon.m.FatigueOnSkillUse;
 		}
+	}
 
+	local randomizeValues = o.randomizeValues;
+	o.randomizeValues <- function()
+	{
+		this.setValuesFromBaseWeapon();
 		randomizeValues();
 	}
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,30 +1,39 @@
 ::mods_hookExactClass("items/weapons/named/named_weapon", function(o) {
 	o.m.BaseWeaponScript <- null;
 
-	o.setValuesFromBaseWeapon <- function()
+	o.getValuesForRandomize <- function()
 	{
-		if (this.m.BaseWeaponScript != null)
+		if (this.m.BaseWeaponScript == null) return {};
+
+		local baseWeapon = ::new(this.m.BaseWeaponScript);
+		return {
+			Condition = baseWeapon.m.Condition;
+			ConditionMax = baseWeapon.m.ConditionMax;
+			RegularDamage = baseWeapon.m.RegularDamage;
+			RegularDamageMax = baseWeapon.m.RegularDamageMax;
+			ArmorDamageMult = baseWeapon.m.ArmorDamageMult;
+			ChanceToHitHead = baseWeapon.m.ChanceToHitHead;
+			DirectDamageMult = baseWeapon.m.DirectDamageMult;
+			DirectDamageAdd = baseWeapon.m.DirectDamageAdd;
+			StaminaModifier = baseWeapon.m.StaminaModifier;
+			ShieldDamage = baseWeapon.m.ShieldDamage;
+			AdditionalAccuracy = baseWeapon.m.AdditionalAccuracy;
+			FatigueOnSkillUse = baseWeapon.m.FatigueOnSkillUse;
+		};
+	}
+
+	o.setValuesForRandomize <- function( _values )
+	{
+		foreach (key, value in _values)
 		{
-			local baseWeapon = ::new(this.m.BaseWeaponScript);
-			this.m.Condition = baseWeapon.m.Condition;
-			this.m.ConditionMax = baseWeapon.m.ConditionMax;
-			this.m.RegularDamage = baseWeapon.m.RegularDamage;
-			this.m.RegularDamageMax = baseWeapon.m.RegularDamageMax;
-			this.m.ArmorDamageMult = baseWeapon.m.ArmorDamageMult;
-			this.m.ChanceToHitHead = baseWeapon.m.ChanceToHitHead;
-			this.m.DirectDamageMult = baseWeapon.m.DirectDamageMult;
-			this.m.DirectDamageAdd = baseWeapon.m.DirectDamageAdd;
-			this.m.StaminaModifier = baseWeapon.m.StaminaModifier;
-			this.m.ShieldDamage = baseWeapon.m.ShieldDamage;
-			this.m.AdditionalAccuracy = baseWeapon.m.AdditionalAccuracy;
-			this.m.FatigueOnSkillUse = baseWeapon.m.FatigueOnSkillUse;
+			this.m[key] = value;
 		}
 	}
 
 	local randomizeValues = o.randomizeValues;
 	o.randomizeValues <- function()
 	{
-		this.setValuesFromBaseWeapon();
+		this.setValuesBeforeRandomize(this.getValuesBeforeRandomize());
 		randomizeValues();
 	}
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,11 +1,12 @@
-::mods_hookExactClass("items/weapons/named/named_weapon", function(o) {
-	o.m.BaseWeaponScript <- null;
+::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
+	q.m.BaseItemScript <- null;
 
-	o.getValuesForRandomize <- function()
+	q.getValuesForRandomize <- function()
 	{
-		if (this.m.BaseWeaponScript == null) return {};
+		if (this.m.BaseItemScript == null)
+			return {};
 
-		local baseWeapon = ::new(this.m.BaseWeaponScript);
+		local baseWeapon = ::new(this.m.BaseItemScript);
 		return {
 			Condition = baseWeapon.m.Condition;
 			ConditionMax = baseWeapon.m.ConditionMax;
@@ -22,7 +23,7 @@
 		};
 	}
 
-	o.setValuesForRandomize <- function( _values )
+	q.setValuesForRandomize <- function( _values )
 	{
 		foreach (key, value in _values)
 		{
@@ -30,10 +31,9 @@
 		}
 	}
 
-	local randomizeValues = o.randomizeValues;
-	o.randomizeValues <- function()
+	q.randomizeValues <- @(__original) function()
 	{
 		this.setValuesBeforeRandomize(this.getValuesBeforeRandomize());
-		randomizeValues();
+		return __original();
 	}
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,6 +1,6 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/weapons/named/named_weapon");
 
-::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
+::MSU.MH.hook("scripts/items/weapons/named/named_weapon", function(q) {
 	q.getBaseItemFields = @() function()
 	{
 		return [

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -4,6 +4,7 @@
 	q.getBaseItemFields = @() function()
 	{
 		return [
+			// The following fields are used in vanilla randomizeValues()
 			"Condition",
 			"ConditionMax",
 			"StaminaModifier",
@@ -17,6 +18,22 @@
 			"ShieldDamage",
 			"AdditionalAccuracy",
 			"FatigueOnSkillUse",
+
+			// The following fields aren't used in vanilla randomizeValues() but we copy them
+			// for the sake of completion so that named items can be based on base items properly
+			"Ammo",
+			"AmmoMax",
+			"AmmoCost",
+			"IsAoE",
+			"SlotType",
+			"BlockedSlotType",
+			"ItemType",
+			"WeaponType",
+			"IsDoubleGrippable",
+			"IsAgainstShields",
+			"RangeMin",
+			"RangeMax",
+			"RangeIdeal",
 		];
 	}
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,6 +1,6 @@
-::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
-	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/weapons/named/named_weapon");
 
+::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -19,10 +19,4 @@
 			"FatigueOnSkillUse"
 		];
 	}
-});
-
-::MSU.QueueBucket.VeryLate.push(function() {
-	::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
-		::MSU.HooksHelper.addBaseItemToNamedItemVeryLate(q);
-	});
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,39 +1,40 @@
 ::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
 	q.m.BaseItemScript <- null;
 
-	q.getValuesForRandomize <- function()
+	q.getFieldsForRandomize <- function()
 	{
-		if (this.m.BaseItemScript == null)
-			return {};
-
-		local baseWeapon = ::new(this.m.BaseItemScript);
-		return {
-			Condition = baseWeapon.m.Condition;
-			ConditionMax = baseWeapon.m.ConditionMax;
-			RegularDamage = baseWeapon.m.RegularDamage;
-			RegularDamageMax = baseWeapon.m.RegularDamageMax;
-			ArmorDamageMult = baseWeapon.m.ArmorDamageMult;
-			ChanceToHitHead = baseWeapon.m.ChanceToHitHead;
-			DirectDamageMult = baseWeapon.m.DirectDamageMult;
-			DirectDamageAdd = baseWeapon.m.DirectDamageAdd;
-			StaminaModifier = baseWeapon.m.StaminaModifier;
-			ShieldDamage = baseWeapon.m.ShieldDamage;
-			AdditionalAccuracy = baseWeapon.m.AdditionalAccuracy;
-			FatigueOnSkillUse = baseWeapon.m.FatigueOnSkillUse;
-		};
+		return [
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier",
+			"RegularDamage",
+			"RegularDamageMax"
+			"ArmorDamageMult"
+			"ChanceToHitHead"
+			"DirectDamageMult"
+			"DirectDamageAdd"
+			"StaminaModifier"
+			"ShieldDamage"
+			"AdditionalAccuracy"
+			"FatigueOnSkillUse"
+		];
 	}
 
-	q.setValuesForRandomize <- function( _values )
+	q.setValuesBeforeRandomize <- function()
 	{
-		foreach (key, value in _values)
+		if (this.m.BaseItemScript == null)
+			return;
+
+		local baseM = ::new(this.m.BaseItemScript).m;
+		foreach (field in this.getFieldsForRandomize())
 		{
-			this.m[key] = value;
+			this.m[field] = baseM[field];
 		}
 	}
 
 	q.randomizeValues <- @(__original) function()
 	{
-		this.setValuesBeforeRandomize(this.getValuesBeforeRandomize());
+		this.setValuesBeforeRandomize();
 		return __original();
 	}
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,6 +1,4 @@
 ::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
-	q.m.BaseItemScript <- null;
-
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -19,22 +17,8 @@
 			"FatigueOnSkillUse"
 		];
 	}
+});
 
-	q.setValuesBeforeRandomize <- function()
-	{
-		if (this.m.BaseItemScript == null)
-			return;
-
-		local baseM = ::new(this.m.BaseItemScript).m;
-		foreach (field in this.getFieldsForRandomize())
-		{
-			this.m[field] = baseM[field];
-		}
-	}
-
-	q.randomizeValues <- @(__original) function()
-	{
-		this.setValuesBeforeRandomize();
-		return __original();
-	}
+::MSU.HooksMod.hookTree("scripts/items/weapons/named/named_weapon", function(q) {
+	::MSU.HooksHelper.addBaseItemToNamedItem(q);
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,4 +1,6 @@
 ::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
+	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+
 	q.getFieldsForRandomize <- function()
 	{
 		return [
@@ -19,6 +21,8 @@
 	}
 });
 
-::MSU.HooksMod.hookTree("scripts/items/weapons/named/named_weapon", function(q) {
-	::MSU.HooksHelper.addBaseItemToNamedItem(q);
+::MSU.QueueBucket.VeryLate.push(function() {
+	::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
+		::MSU.HooksHelper.addBaseItemToNamedItemVeryLate(q);
+	});
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,22 +1,19 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/weapons/named/named_weapon");
 
 ::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
-	q.getFieldsForRandomize <- function()
-	{
-		return [
-			"Condition",
-			"ConditionMax",
-			"StaminaModifier",
-			"RegularDamage",
-			"RegularDamageMax",
-			"ArmorDamageMult",
-			"ChanceToHitHead",
-			"DirectDamageMult",
-			"DirectDamageAdd",
-			"StaminaModifier",
-			"ShieldDamage",
-			"AdditionalAccuracy",
-			"FatigueOnSkillUse"
-		];
-	}
+	q.m.BaseItemFields = [
+		"Condition",
+		"ConditionMax",
+		"StaminaModifier",
+		"RegularDamage",
+		"RegularDamageMax",
+		"ArmorDamageMult",
+		"ChanceToHitHead",
+		"DirectDamageMult",
+		"DirectDamageAdd",
+		"StaminaModifier",
+		"ShieldDamage",
+		"AdditionalAccuracy",
+		"FatigueOnSkillUse"
+	];
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -1,19 +1,22 @@
 ::MSU.HooksHelper.addBaseItemToNamedItem("scripts/items/weapons/named/named_weapon");
 
 ::MSU.HooksMod.hook("scripts/items/weapons/named/named_weapon", function(q) {
-	q.m.BaseItemFields = [
-		"Condition",
-		"ConditionMax",
-		"StaminaModifier",
-		"RegularDamage",
-		"RegularDamageMax",
-		"ArmorDamageMult",
-		"ChanceToHitHead",
-		"DirectDamageMult",
-		"DirectDamageAdd",
-		"StaminaModifier",
-		"ShieldDamage",
-		"AdditionalAccuracy",
-		"FatigueOnSkillUse"
-	];
+	q.getBaseItemFields = @() function()
+	{
+		return [
+			"Condition",
+			"ConditionMax",
+			"StaminaModifier",
+			"RegularDamage",
+			"RegularDamageMax",
+			"ArmorDamageMult",
+			"ChanceToHitHead",
+			"DirectDamageMult",
+			"DirectDamageAdd",
+			"StaminaModifier",
+			"ShieldDamage",
+			"AdditionalAccuracy",
+			"FatigueOnSkillUse",
+		];
+	}
 });

--- a/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
+++ b/msu/hooks/items/weapons/named/named_weapon/named_weapon.nut
@@ -8,14 +8,14 @@
 			"ConditionMax",
 			"StaminaModifier",
 			"RegularDamage",
-			"RegularDamageMax"
-			"ArmorDamageMult"
-			"ChanceToHitHead"
-			"DirectDamageMult"
-			"DirectDamageAdd"
-			"StaminaModifier"
-			"ShieldDamage"
-			"AdditionalAccuracy"
+			"RegularDamageMax",
+			"ArmorDamageMult",
+			"ChanceToHitHead",
+			"DirectDamageMult",
+			"DirectDamageAdd",
+			"StaminaModifier",
+			"ShieldDamage",
+			"AdditionalAccuracy",
 			"FatigueOnSkillUse"
 		];
 	}

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -3,6 +3,7 @@
 	{
 		::MSU.HooksMod.hook(_script, function(q) {
 			q.m.BaseItemScript <- null;
+			q.m.MSU_PreventRandomize <- false;
 
 			q.getBaseItemFields <- function()
 			{
@@ -26,11 +27,23 @@
 		});
 
 		::MSU.QueueBucket.VeryLate.push(function() {
-			::MSU.HooksMod.hook(_script, function(q) {
+			::MSU.HooksMod.hookTree(_script, function(q) {
+				q.create = @(__original) function()
+				{
+					// Prevent the vanilla call to this.randomizeValues() within create() from randomizing anything
+					// because we want to set the values from the base item first.
+					this.m.MSU_PreventRandomize = true;
+					__original();
+					this.m.MSU_PreventRandomize = false;
+
+					this.setValuesBeforeRandomize();
+					this.randomizeValues();
+				}
+
 				q.randomizeValues = @(__original) function()
 				{
-					this.setValuesBeforeRandomize();
-					return __original();
+					if (!this.m.MSU_PreventRandomize)
+						return __original();
 				}
 			});
 		});

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -14,7 +14,10 @@
 				this.m[field] = baseM[field];
 			}
 		}
+	}
 
+	function addBaseItemToNamedItemVeryLate( _q )
+	{
 		_q.randomizeValues <- @(__original) function()
 		{
 			this.setValuesBeforeRandomize();

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -17,6 +17,8 @@
 					{
 						this.m[field] = _baseItem.m[field];
 					}
+
+					this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.Named; // Re-add the named item type that got overwritten from the base item
 				}
 			}
 		});
@@ -32,11 +34,7 @@
 					__original();
 					this.randomizeValues = randomizeValues;
 
-					local hasNamedItemType = this.isItemType(::Const.Items.ItemType.Named);
 					this.setValuesBeforeRandomize(this.m.BaseItemScript != null ? ::new(this.m.BaseItemScript) : null);
-					if (hasNamedItemType)
-						this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.Named; // Re-add the named item type that got overwritten from the base item
-
 					this.randomizeValues();
 				}
 			});

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -3,7 +3,6 @@
 	{
 		::MSU.HooksMod.hook(_script, function(q) {
 			q.m.BaseItemScript <- null;
-			q.m.MSU_PreventRandomize <- false;
 
 			q.getBaseItemFields <- function()
 			{
@@ -32,18 +31,13 @@
 				{
 					// Prevent the vanilla call to this.randomizeValues() within create() from randomizing anything
 					// because we want to set the values from the base item first.
-					this.m.MSU_PreventRandomize = true;
+					local randomizeValues = this.randomizeValues;
+					this.randomizeValues = @() null;
 					__original();
-					this.m.MSU_PreventRandomize = false;
+					this.randomizeValues = randomizeValues;
 
 					this.setValuesBeforeRandomize();
 					this.randomizeValues();
-				}
-
-				q.randomizeValues = @(__original) function()
-				{
-					if (!this.m.MSU_PreventRandomize)
-						return __original();
 				}
 			});
 		});

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -1,23 +1,26 @@
 ::MSU.HooksHelper <- {
-	function addBaseItemToNamedItem( _q )
+	function addBaseItemToNamedItem( _script )
 	{
-		_q.m.BaseItemScript <- null;
-	}
+		::MSU.HooksMod.hook(_script, function(q) {
+			q.m.BaseItemScript <- null;
+		});
 
-	function addBaseItemToNamedItemVeryLate( _q )
-	{
-		_q.randomizeValues = @(__original) function()
-		{
-			if (this.m.BaseItemScript != null)
-			{
-				local baseM = ::new(this.m.BaseItemScript).m;
-				foreach (field in this.getFieldsForRandomize())
+		::MSU.QueueBucket.VeryLate.push(function() {
+			::MSU.HooksMod.hook(_script, function(q) {
+				q.randomizeValues = @(__original) function()
 				{
-					this.m[field] = baseM[field];
-				}
-			}
+					if (this.m.BaseItemScript != null)
+					{
+						local baseM = ::new(this.m.BaseItemScript).m;
+						foreach (field in this.getFieldsForRandomize())
+						{
+							this.m[field] = baseM[field];
+						}
+					}
 
-			return __original();
-		}
+					return __original();
+				}
+			});
+		});
 	}
 }

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -15,10 +15,7 @@
 				{
 					foreach (field in this.getBaseItemFields())
 					{
-						if (field == "ItemType")
-							this.m[field] = this.m.ItemType | _baseItem.m.ItemType;
-						else
-							this.m[field] = _baseItem.m[field];
+						this.m[field] = _baseItem.m[field];
 					}
 				}
 			}
@@ -35,7 +32,11 @@
 					__original();
 					this.randomizeValues = randomizeValues;
 
+					local hasNamedItemType = this.isItemType(::Const.Items.ItemType.Named);
 					this.setValuesBeforeRandomize(this.m.BaseItemScript != null ? ::new(this.m.BaseItemScript) : null);
+					if (hasNamedItemType)
+						this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.Named; // Re-add the named item type that got overwritten from the base item
+
 					this.randomizeValues();
 				}
 			});

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -9,17 +9,16 @@
 				return [];
 			}
 
-			q.setValuesBeforeRandomize <- function()
+			q.setValuesBeforeRandomize <- function( _baseItem )
 			{
-				if (this.m.BaseItemScript != null)
+				if (_baseItem != null)
 				{
-					local baseM = ::new(this.m.BaseItemScript).m;
 					foreach (field in this.getBaseItemFields())
 					{
 						if (field == "ItemType")
-							this.m[field] = this.m.ItemType | baseM.ItemType;
+							this.m[field] = this.m.ItemType | _baseItem.m.ItemType;
 						else
-							this.m[field] = baseM[field];
+							this.m[field] = _baseItem.m[field];
 					}
 				}
 			}
@@ -36,7 +35,7 @@
 					__original();
 					this.randomizeValues = randomizeValues;
 
-					this.setValuesBeforeRandomize();
+					this.setValuesBeforeRandomize(this.m.BaseItemScript != null ? ::new(this.m.BaseItemScript) : null);
 					this.randomizeValues();
 				}
 			});

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -1,0 +1,1 @@
+::MSU.HooksHelper <- {}

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -18,7 +18,7 @@
 
 	function addBaseItemToNamedItemVeryLate( _q )
 	{
-		_q.randomizeValues <- @(__original) function()
+		_q.randomizeValues = @(__original) function()
 		{
 			this.setValuesBeforeRandomize();
 			return __original();

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -2,25 +2,21 @@
 	function addBaseItemToNamedItem( _q )
 	{
 		_q.m.BaseItemScript <- null;
-
-		_q.setValuesBeforeRandomize <- function()
-		{
-			if (this.m.BaseItemScript == null)
-				return;
-
-			local baseM = ::new(this.m.BaseItemScript).m;
-			foreach (field in this.getFieldsForRandomize())
-			{
-				this.m[field] = baseM[field];
-			}
-		}
 	}
 
 	function addBaseItemToNamedItemVeryLate( _q )
 	{
 		_q.randomizeValues = @(__original) function()
 		{
-			this.setValuesBeforeRandomize();
+			if (this.m.BaseItemScript != null)
+			{
+				local baseM = ::new(this.m.BaseItemScript).m;
+				foreach (field in this.getFieldsForRandomize())
+				{
+					this.m[field] = baseM[field];
+				}
+			}
+
 			return __original();
 		}
 	}

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -1,1 +1,24 @@
-::MSU.HooksHelper <- {}
+::MSU.HooksHelper <- {
+	function addBaseItemToNamedItem( _q )
+	{
+		_q.m.BaseItemScript <- null;
+
+		_q.setValuesBeforeRandomize <- function()
+		{
+			if (this.m.BaseItemScript == null)
+				return;
+
+			local baseM = ::new(this.m.BaseItemScript).m;
+			foreach (field in this.getFieldsForRandomize())
+			{
+				this.m[field] = baseM[field];
+			}
+		}
+
+		_q.randomizeValues <- @(__original) function()
+		{
+			this.setValuesBeforeRandomize();
+			return __original();
+		}
+	}
+}

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -3,6 +3,7 @@
 	{
 		::MSU.HooksMod.hook(_script, function(q) {
 			q.m.BaseItemScript <- null;
+			q.m.BaseItemFields <- [];
 		});
 
 		::MSU.QueueBucket.VeryLate.push(function() {
@@ -12,7 +13,7 @@
 					if (this.m.BaseItemScript != null)
 					{
 						local baseM = ::new(this.m.BaseItemScript).m;
-						foreach (field in this.getFieldsForRandomize())
+						foreach (field in this.m.BaseItemFields)
 						{
 							this.m[field] = baseM[field];
 						}

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -4,21 +4,24 @@
 		::MSU.HooksMod.hook(_script, function(q) {
 			q.m.BaseItemScript <- null;
 			q.m.BaseItemFields <- [];
+			q.setValuesBeforeRandomize <- function()
+			{
+				if (this.m.BaseItemScript != null)
+				{
+					local baseM = ::new(this.m.BaseItemScript).m;
+					foreach (field in this.m.BaseItemFields)
+					{
+						this.m[field] = baseM[field];
+					}
+				}
+			}
 		});
 
 		::MSU.QueueBucket.VeryLate.push(function() {
 			::MSU.HooksMod.hook(_script, function(q) {
 				q.randomizeValues = @(__original) function()
 				{
-					if (this.m.BaseItemScript != null)
-					{
-						local baseM = ::new(this.m.BaseItemScript).m;
-						foreach (field in this.m.BaseItemFields)
-						{
-							this.m[field] = baseM[field];
-						}
-					}
-
+					this.setValuesBeforeRandomize();
 					return __original();
 				}
 			});

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -1,7 +1,7 @@
 ::MSU.HooksHelper <- {
 	function addBaseItemToNamedItem( _script )
 	{
-		::MSU.HooksMod.hook(_script, function(q) {
+		::MSU.MH.hook(_script, function(q) {
 			q.m.BaseItemScript <- null;
 
 			q.getBaseItemFields <- function()
@@ -26,7 +26,7 @@
 		});
 
 		::MSU.QueueBucket.VeryLate.push(function() {
-			::MSU.HooksMod.hookTree(_script, function(q) {
+			::MSU.MH.hookTree(_script, function(q) {
 				q.create = @(__original) function()
 				{
 					// Prevent the vanilla call to this.randomizeValues() within create() from randomizing anything

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -3,13 +3,18 @@
 	{
 		::MSU.HooksMod.hook(_script, function(q) {
 			q.m.BaseItemScript <- null;
-			q.m.BaseItemFields <- [];
+
+			q.getBaseItemFields <- function()
+			{
+				return [];
+			}
+
 			q.setValuesBeforeRandomize <- function()
 			{
 				if (this.m.BaseItemScript != null)
 				{
 					local baseM = ::new(this.m.BaseItemScript).m;
-					foreach (field in this.m.BaseItemFields)
+					foreach (field in this.getBaseItemFields())
 					{
 						if (field == "ItemType")
 							this.m[field] = this.m.ItemType | baseM.ItemType;

--- a/msu/hooks_helper/hooks_helper.nut
+++ b/msu/hooks_helper/hooks_helper.nut
@@ -11,7 +11,10 @@
 					local baseM = ::new(this.m.BaseItemScript).m;
 					foreach (field in this.m.BaseItemFields)
 					{
-						this.m[field] = baseM[field];
+						if (field == "ItemType")
+							this.m[field] = this.m.ItemType | baseM.ItemType;
+						else
+							this.m[field] = baseM[field];
 					}
 				}
 			}

--- a/msu/hooks_helper/load.nut
+++ b/msu/hooks_helper/load.nut
@@ -1,0 +1,1 @@
+::MSU.includeFiles(::IO.enumerateFiles("msu/hooks_helper"));

--- a/msu/load.nut
+++ b/msu/load.nut
@@ -12,5 +12,3 @@ includeLoad("hooks");
 includeLoad("msu_mod");
 includeLoad("vanilla_mod");
 includeLoad("test");
-
-delete ::MSU.HooksHelper;

--- a/msu/load.nut
+++ b/msu/load.nut
@@ -12,3 +12,5 @@ includeLoad("hooks");
 includeLoad("msu_mod");
 includeLoad("vanilla_mod");
 includeLoad("test");
+
+delete ::MSU.HooksHelper;

--- a/msu/load.nut
+++ b/msu/load.nut
@@ -7,6 +7,7 @@ local function includeLoad( _folder )
 
 includeLoad("ui");
 includeLoad("systems");
+includeLoad("hooks_helper");
 includeLoad("hooks");
 includeLoad("msu_mod");
 includeLoad("vanilla_mod");

--- a/scripts/!mods_preload/msu.nut
+++ b/scripts/!mods_preload/msu.nut
@@ -33,6 +33,7 @@
 	}
 	::MSU.QueueBucket.FirstWorldInit.clear();
 	delete ::MSU.QueueBucket;
+	delete ::MSU.HooksHelper;
 }, ::Hooks.QueueBucket.FirstWorldInit);
 
 ::MSU.QueueBucket.FirstWorldInit.push(function() {


### PR DESCRIPTION
We should make a list of fields in `::MSU.Items.BaseWeaponFields` and iterate over that to allow easy way for modders to change the fields which are copied over from the Base Weapon. I will do this after #176 is merged (because of folder structure, to avoid resolving conflicts).