### PR TITLE
feat: keep a history of how many times a non-stacking skill was added or removed and add or remove it accordingly

### DIFF
--- a/msu/hooks/items/item_container.nut
+++ b/msu/hooks/items/item_container.nut
@@ -1,6 +1,9 @@
 ::mods_hookNewObject("items/item_container", function(o) {
 	o.m.ActionSkill <- null;
 	o.m.MSU_IsIgnoringItemAction <- false;
+	o.m.MSU <- {
+		ItemBeingUnequipped = null
+	}
 
 	o.isActionAffordable = function ( _items )
 	{
@@ -92,6 +95,11 @@
 	local unequip = o.unequip;
 	o.unequip = function( _item )
 	{
+		// This variable is needed for proper functionality in the skill.removeSelf function because
+		// in that function we want to know if the item being unequipped is the one that is attached to that skill
+		// and skills are removed before the item is unequipped
+		this.m.MSU.ItemBeingUnequipped = _item;
+
 		if (_item != null && _item != -1 && _item.getCurrentSlotType() != ::Const.ItemSlot.None && _item.getCurrentSlotType() != ::Const.ItemSlot.Bag && !::MSU.isNull(this.m.Actor) && this.m.Actor.isAlive())
 		{
 			foreach (item in this.m.Items[_item.getSlotType()])
@@ -104,6 +112,10 @@
 			}
 		}
 
-		return unequip(_item);
+		local ret = unequip(_item);
+
+		this.m.MSU.ItemBeingUnequipped = null;
+
+		return ret;
 	}
 });

--- a/msu/hooks/items/item_container.nut
+++ b/msu/hooks/items/item_container.nut
@@ -1,9 +1,7 @@
 ::mods_hookNewObject("items/item_container", function(o) {
 	o.m.ActionSkill <- null;
 	o.m.MSU_IsIgnoringItemAction <- false;
-	o.m.MSU <- {
-		ItemBeingUnequipped = null
-	}
+	o.m.MSU_ItemBeingUnequipped <- null;
 
 	o.isActionAffordable = function ( _items )
 	{
@@ -98,7 +96,7 @@
 		// This variable is needed for proper functionality in the skill.removeSelf function because
 		// in that function we want to know if the item being unequipped is the one that is attached to that skill
 		// and skills are removed before the item is unequipped
-		this.m.MSU.ItemBeingUnequipped = _item;
+		this.m.MSU_ItemBeingUnequipped = _item;
 
 		if (_item != null && _item != -1 && _item.getCurrentSlotType() != ::Const.ItemSlot.None && _item.getCurrentSlotType() != ::Const.ItemSlot.Bag && !::MSU.isNull(this.m.Actor) && this.m.Actor.isAlive())
 		{
@@ -114,7 +112,7 @@
 
 		local ret = unequip(_item);
 
-		this.m.MSU.ItemBeingUnequipped = null;
+		this.m.MSU_ItemBeingUnequipped = null;
 
 		return ret;
 	}

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -364,9 +364,9 @@
 		this.setItem(null);
 	}
 
-	function isKeepingAddRemoveHistory()
+	o.isKeepingAddRemoveHistory <- function()
 	{
-		return !this.isStacking() && !(this.isType(::Const.SkillType.Perk) || !this.isType(::Const.SkillType.StatusEffect));
+		return !this.isStacking() && (this.isType(::Const.SkillType.Perk) || !this.isType(::Const.SkillType.StatusEffect));
 	}
 
 	o.getDamageType <- function()

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -339,12 +339,12 @@
 	{
 		if (!_skill.isKeepingAddRemoveHistory()) return removeSelf();
 
-		if (--this.m.MSU.AddedStack == 0) return removeSelf();
+		if (--this.m.MSU_AddedStack == 0) return removeSelf();
 
 		// The actual item which provided this skill isn't unequipped yet because
 		// the removeSelf is called BEFORE the item is unequipped. So, we iterate over
 		// all items and skip the one that is going to be unequipped
-		if (::MSU.isEqual(this.getContainer().getActor().getItems().m.MSU.ItemBeingUnequipped, this.getItem()))
+		if (::MSU.isEqual(this.getContainer().getActor().getItems().m.MSU_ItemBeingUnequipped, this.getItem()))
 		{
 			foreach (item in this.getContainer().getActor().getItems().getAllItems())
 			{

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -344,7 +344,7 @@
 		else
 		{			
 			if (--this.m.MSU.AddedStack <= 0) removeSelf();
-			else if (::MSU.isNull(this.getItem()) || ::MSU.isNull(this.getItem().getContainer()) || !::MSU.isEqual(this.getItem().getContainer().getActor(), this.getContainer().getActor()))
+			else if (::MSU.isNull(this.getItem()) || ::MSU.isNull(this.getItem().getContainer()) || this.getItem().getContainer().getActor().getID() != this.getContainer().getActor().getID())
 			{
 				foreach (item in this.getContainer().getActor().getItems().getAllItems())
 				{

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -341,7 +341,7 @@
 
 		if (--this.m.MSU.AddedStack == 0) return removeSelf();
 
-		if (::MSU.isNull(this.getItem()) || ::MSU.isNull(this.getItem().getContainer()) || this.getItem().getContainer().getActor().getID() != this.getContainer().getActor().getID())
+		if (::MSU.isNull(this.getItem()) || !::MSU.isEqual(this.getItem().getContainer(), this.getContainer().getActor().getItems()))
 		{
 			foreach (item in this.getContainer().getActor().getItems().getAllItems())
 			{

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -341,10 +341,15 @@
 
 		if (--this.m.MSU.AddedStack == 0) return removeSelf();
 
-		if (::MSU.isNull(this.getItem()) || !::MSU.isEqual(this.getItem().getContainer(), this.getContainer().getActor().getItems()))
+		// The actual item which provided this skill isn't unequipped yet because
+		// the removeSelf is called BEFORE the item is unequipped. So, we iterate over
+		// all items and skip the one that is going to be unequipped
+		if (::MSU.isEqual(this.getContainer().getActor().getItems().m.MSU.ItemBeingUnequipped, this.getItem()))
 		{
 			foreach (item in this.getContainer().getActor().getItems().getAllItems())
 			{
+				if (::MSU.isEqual(item, this.getItem())) continue;
+
 				foreach (skill in item.m.SkillPtrs)
 				{
 					if (skill.getID() == this.getID())
@@ -354,9 +359,9 @@
 					}
 				}
 			}
-
-			this.setItem(null);
 		}
+
+		this.setItem(null);
 	}
 
 	o.getDamageType <- function()

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -337,29 +337,25 @@
 	local removeSelf = o.removeSelf;
 	o.removeSelf = function()
 	{
-		if (this.isStacking())
+		if (this.isStacking()) return removeSelf();
+
+		if (--this.m.MSU.AddedStack <= 0) return removeSelf();
+
+		if (::MSU.isNull(this.getItem()) || ::MSU.isNull(this.getItem().getContainer()) || this.getItem().getContainer().getActor().getID() != this.getContainer().getActor().getID())
 		{
-			return removeSelf();
-		}
-		else
-		{			
-			if (--this.m.MSU.AddedStack <= 0) return removeSelf();
-			else if (::MSU.isNull(this.getItem()) || ::MSU.isNull(this.getItem().getContainer()) || this.getItem().getContainer().getActor().getID() != this.getContainer().getActor().getID())
+			foreach (item in this.getContainer().getActor().getItems().getAllItems())
 			{
-				foreach (item in this.getContainer().getActor().getItems().getAllItems())
+				foreach (skill in item.m.SkillPtrs)
 				{
-					foreach (skill in item.m.SkillPtrs)
+					if (skill.getID() == this.getID())
 					{
-						if (skill.getID() == this.getID())
-						{
-							this.setItem(item);
-							return;
-						}
+						this.setItem(item);
+						return;
 					}
 				}
-
-				this.setItem(null);
 			}
+
+			this.setItem(null);
 		}
 	}
 

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -344,12 +344,10 @@
 		else
 		{			
 			if (--this.m.MSU.AddedStack <= 0) removeSelf();
-			else
+			else if (::MSU.isNull(this.getItem()) || ::MSU.isNull(this.getItem().getContainer()) || !::MSU.isEqual(this.getItem().getContainer().getActor(), this.getContainer().getActor()))
 			{
 				foreach (item in this.getContainer().getActor().getItems().getAllItems())
 				{
-					if (!::MSU.isNull(this.getItem()) && this.getItem().getID() == item.getID()) continue;
-
 					foreach (skill in item.m.SkillPtrs)
 					{
 						if (skill.getID() == this.getID())

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -55,6 +55,8 @@
 ::mods_hookBaseClass("skills/skill", function(o) {
 	o = o[o.SuperName];
 
+	o.m.MSU_AddedStack <- 1;
+
 	o.m.AIBehaviorID <- null;
 	o.m.DamageType <- ::MSU.Class.WeightedContainer();
 	o.m.ItemActionOrder <- ::Const.ItemActionOrder.Any;
@@ -330,6 +332,38 @@
 		container.onAnySkillExecuted(this, _targetTile, targetEntity, _forFree);
 
 		return ret;
+	}
+
+	local removeSelf = o.removeSelf;
+	o.removeSelf = function()
+	{
+		if (this.isStacking())
+		{
+			removeSelf();
+		}
+		else
+		{
+			this.m.MSU_AddedStack--;
+			if (this.m.MSU_AddedStack <= 0) removeSelf();
+			else
+			{
+				foreach (item in this.getContainer().getActor().getItems().getAllItems())
+				{
+					if (!::MSU.isNull(this.getItem()) && this.getItem().getID() == item.getID()) continue;
+
+					foreach (skill in item.m.SkillPtrs)
+					{
+						if (skill.getID() == this.getID())
+						{
+							this.setItem(item);
+							return;
+						}
+					}
+				}
+
+				this.setItem(null);
+			}
+		}
 	}
 
 	o.getDamageType <- function()

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -342,9 +342,8 @@
 			removeSelf();
 		}
 		else
-		{
-			this.m.MSU_AddedStack--;
-			if (this.m.MSU_AddedStack <= 0) removeSelf();
+		{			
+			if (--this.m.MSU_AddedStack <= 0) removeSelf();
 			else
 			{
 				foreach (item in this.getContainer().getActor().getItems().getAllItems())

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -337,7 +337,7 @@
 	local removeSelf = o.removeSelf;
 	o.removeSelf = function()
 	{
-		if (this.isStacking()) return removeSelf();
+		if (!_skill.isKeepingAddRemoveHistory()) return removeSelf();
 
 		if (--this.m.MSU.AddedStack == 0) return removeSelf();
 
@@ -362,6 +362,11 @@
 		}
 
 		this.setItem(null);
+	}
+
+	function isKeepingAddRemoveHistory()
+	{
+		return !this.isStacking() && !(this.isType(::Const.SkillType.Perk) || !this.isType(::Const.SkillType.StatusEffect));
 	}
 
 	o.getDamageType <- function()

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -343,7 +343,7 @@
 		}
 		else
 		{			
-			if (--this.m.MSU_AddedStack <= 0) removeSelf();
+			if (--this.m.MSU.AddedStack <= 0) removeSelf();
 			else
 			{
 				foreach (item in this.getContainer().getActor().getItems().getAllItems())

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -337,7 +337,7 @@
 	local removeSelf = o.removeSelf;
 	o.removeSelf = function()
 	{
-		if (!_skill.isKeepingAddRemoveHistory()) return removeSelf();
+		if (!this.isKeepingAddRemoveHistory()) return removeSelf();
 
 		if (--this.m.MSU_AddedStack == 0) return removeSelf();
 

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -339,11 +339,11 @@
 	{
 		if (this.isStacking())
 		{
-			removeSelf();
+			return removeSelf();
 		}
 		else
 		{			
-			if (--this.m.MSU.AddedStack <= 0) removeSelf();
+			if (--this.m.MSU.AddedStack <= 0) return removeSelf();
 			else if (::MSU.isNull(this.getItem()) || ::MSU.isNull(this.getItem().getContainer()) || this.getItem().getContainer().getActor().getID() != this.getContainer().getActor().getID())
 			{
 				foreach (item in this.getContainer().getActor().getItems().getAllItems())

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -339,7 +339,7 @@
 	{
 		if (this.isStacking()) return removeSelf();
 
-		if (--this.m.MSU.AddedStack <= 0) return removeSelf();
+		if (--this.m.MSU.AddedStack == 0) return removeSelf();
 
 		if (::MSU.isNull(this.getItem()) || ::MSU.isNull(this.getItem().getContainer()) || this.getItem().getContainer().getActor().getID() != this.getContainer().getActor().getID())
 		{

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -55,8 +55,7 @@
 					}
 				}
 
-				if (alreadyPresentSkill.m.MSU.AddedStack > 1 && i < this.m.Skills.len()) alreadyPresentSkill.onRefresh();
-				return;
+				break;
 			}
 		}
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -32,30 +32,35 @@
 	{
 		if (!_skill.isStacking())
 		{
+			local incrementAddedStack = function( _alreadyPresentSkill, _skillToAdd )
+			{
+				_alreadyPresentSkill.m.MSU_AddedStack += 1;
+				if (!::MSU.isNull(_skillToAdd.getItem()))
+				{
+					_alreadyPresentSkill.setItem(_skillToAdd.getItem());
+					foreach (i, itemSkill in _skillToAdd.getItem().m.SkillPtrs)
+					{
+						if (itemSkill.getID() == _skillToAdd.getID())
+						{
+							_skillToAdd.getItem().m.SkillPtrs[i] = _alreadyPresentSkill;
+							_skillToAdd.setItem(null);
+							break;
+						}
+					}
+				}
+
+				if (_alreadyPresentSkill.m.MSU_AddedStack > 0)
+				{
+					_alreadyPresentSkill.m.IsGarbage = false;
+				}
+			}
+
 			foreach (i, alreadyPresentSkill in this.m.Skills)
 			{
 				if (alreadyPresentSkill.getID() == _skill.getID())
 				{
-					alreadyPresentSkill.m.MSU_AddedStack += 1;
-					if (!::MSU.isNull(_skill.getItem()))
-					{
-						alreadyPresentSkill.setItem(_skill.getItem());
-						foreach (i, itemSkill in _skill.getItem().m.SkillPtrs)
-						{
-							if (itemSkill.getID() == _skill.getID())
-							{
-								_skill.getItem().m.SkillPtrs[i] = alreadyPresentSkill;
-								_skill.setItem(null);
-								break;
-							}
-						}
-					}
-
-					if (alreadyPresentSkill.m.MSU_AddedStack > 0)
-					{
-						alreadyPresentSkill.m.IsGarbage = false;
-					}
-
+					incrementAddedStack(alreadyPresentSkill, _skill);
+					if (alreadyPresentSkill.m.MSU_AddedStack > 1) alreadyPresentSkill.onRefresh();
 					return;
 				}
 			}
@@ -64,26 +69,7 @@
 			{
 				if (alreadyPresentSkill.getID() == _skill.getID())
 				{
-					alreadyPresentSkill.m.MSU_AddedStack += 1;
-					if (!::MSU.isNull(_skill.getItem()))
-					{
-						alreadyPresentSkill.setItem(_skill.getItem());
-						foreach (i, itemSkill in _skill.getItem().m.SkillPtrs)
-						{
-							if (itemSkill.getID() == _skill.getID())
-							{
-								_skill.getItem().m.SkillPtrs[i] = alreadyPresentSkill;
-								_skill.setItem(null);
-								break;
-							}
-						}
-					}
-
-					if (alreadyPresentSkill.m.MSU_AddedStack > 0)
-					{
-						alreadyPresentSkill.m.IsGarbage = false;
-					}
-
+					incrementAddedStack(alreadyPresentSkill, _skill);
 					return;
 				}
 			}

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -34,7 +34,7 @@
 		{
 			local incrementAddedStack = function( _alreadyPresentSkill, _skillToAdd )
 			{
-				_alreadyPresentSkill.m.MSU_AddedStack += 1;
+				_alreadyPresentSkill.m.MSU.AddedStack += 1;
 				if (!::MSU.isNull(_skillToAdd.getItem()))
 				{
 					_alreadyPresentSkill.setItem(_skillToAdd.getItem());
@@ -49,7 +49,7 @@
 					}
 				}
 
-				if (_alreadyPresentSkill.m.MSU_AddedStack > 0)
+				if (_alreadyPresentSkill.m.MSU.AddedStack > 0)
 				{
 					_alreadyPresentSkill.m.IsGarbage = false;
 				}
@@ -60,7 +60,7 @@
 				if (alreadyPresentSkill.getID() == _skill.getID())
 				{
 					incrementAddedStack(alreadyPresentSkill, _skill);
-					for (local i = 1; i < alreadyPresentSkill.m.MSU_AddedStack; i++)
+					for (local i = 1; i < alreadyPresentSkill.m.MSU.AddedStack; i++)
 					{
 						alreadyPresentSkill.onRefresh();
 					}					
@@ -84,7 +84,7 @@
 	local remove = o.remove;
 	o.remove = function( _skill )
 	{
-		if (_skill.m.MSU_AddedStack == 1) remove(_skill);
+		if (_skill.m.MSU.AddedStack == 1) remove(_skill);
 		else _skill.removeSelf();
 	}
 
@@ -94,7 +94,7 @@
 		local skill = this.getSkillByID(_skillID);
 		if (skill == null) return;
 
-		if (skill.m.MSU_AddedStack == 1) removeByID(_skillID);
+		if (skill.m.MSU.AddedStack == 1) removeByID(_skillID);
 		else skill.removeSelf();
 	}
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -39,7 +39,7 @@
 		{
 			if (alreadyPresentSkill.getID() == _skill.getID())
 			{
-				if (++alreadyPresentSkill.m.MSU.AddedStack > 0) alreadyPresentSkill.m.IsGarbage = false;
+				if (++alreadyPresentSkill.m.MSU_AddedStack > 0) alreadyPresentSkill.m.IsGarbage = false;
 
 				if (!::MSU.isNull(_skill.getItem()))
 				{
@@ -65,7 +65,7 @@
 	local remove = o.remove;
 	o.remove = function( _skill )
 	{
-		if (_skill.m.MSU.AddedStack == 1) return remove(_skill);
+		if (_skill.m.MSU_AddedStack == 1) return remove(_skill);
 		else return _skill.removeSelf();
 	}
 
@@ -75,7 +75,7 @@
 		local skill = this.getSkillByID(_skillID);
 		if (skill == null) return;
 
-		if (skill.m.MSU.AddedStack == 1) return removeByID(_skillID);
+		if (skill.m.MSU_AddedStack == 1) return removeByID(_skillID);
 		else return skill.removeSelf();
 	}
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -30,59 +30,52 @@
 	local add = o.add;
 	o.add = function( _skill, _order = 0 )
 	{
-		if (!_skill.isStacking())
+		if (_skill.isStacking()) return add(_skill, _order);
+
+		local incrementAddedStack = function( _alreadyPresentSkill, _skillToAdd )
 		{
-			local incrementAddedStack = function( _alreadyPresentSkill, _skillToAdd )
+			if (++_alreadyPresentSkill.m.MSU.AddedStack > 0) _alreadyPresentSkill.m.IsGarbage = false;
+
+			if (!::MSU.isNull(_skillToAdd.getItem()))
 			{
-				_alreadyPresentSkill.m.MSU.AddedStack += 1;
-				if (!::MSU.isNull(_skillToAdd.getItem()))
+				if (::MSU.isNull(_alreadyPresentSkill.getItem()) _alreadyPresentSkill.setItem(_skillToAdd.getItem());
+				foreach (i, itemSkill in _skillToAdd.getItem().m.SkillPtrs)
 				{
-					if (::MSU.isNull(_alreadyPresentSkill.getItem()) _alreadyPresentSkill.setItem(_skillToAdd.getItem());
-					foreach (i, itemSkill in _skillToAdd.getItem().m.SkillPtrs)
+					if (itemSkill.getID() == _skillToAdd.getID())
 					{
-						if (itemSkill.getID() == _skillToAdd.getID())
-						{
-							_skillToAdd.getItem().m.SkillPtrs[i] = _alreadyPresentSkill;
-							_skillToAdd.setItem(null);
-							break;
-						}
+						_skillToAdd.getItem().m.SkillPtrs[i] = _alreadyPresentSkill;
+						_skillToAdd.setItem(null);
+						break;
 					}
-				}
-
-				if (_alreadyPresentSkill.m.MSU.AddedStack > 0)
-				{
-					_alreadyPresentSkill.m.IsGarbage = false;
-				}
-			}
-
-			foreach (i, alreadyPresentSkill in this.m.Skills)
-			{
-				if (alreadyPresentSkill.getID() == _skill.getID())
-				{
-					incrementAddedStack(alreadyPresentSkill, _skill);
-					if (alreadyPresentSkill.m.MSU.AddedStack > 1) alreadyPresentSkill.onRefresh();
-					return;
-				}
-			}
-
-			foreach (i, alreadyPresentSkill in this.m.SkillsToAdd)
-			{
-				if (alreadyPresentSkill.getID() == _skill.getID())
-				{
-					incrementAddedStack(alreadyPresentSkill, _skill);
-					return;
 				}
 			}
 		}
 
-		add(_skill, _order);
+		foreach (alreadyPresentSkill in this.m.Skills)
+		{
+			if (alreadyPresentSkill.getID() == _skill.getID())
+			{
+				incrementAddedStack(alreadyPresentSkill, _skill);
+				if (alreadyPresentSkill.m.MSU.AddedStack > 1) alreadyPresentSkill.onRefresh();
+				return;
+			}
+		}
+
+		foreach (alreadyPresentSkill in this.m.SkillsToAdd)
+		{
+			if (alreadyPresentSkill.getID() == _skill.getID())
+			{
+				incrementAddedStack(alreadyPresentSkill, _skill);
+				return;
+			}
+		}
 	}
 
 	local remove = o.remove;
 	o.remove = function( _skill )
 	{
-		if (_skill.m.MSU.AddedStack == 1) remove(_skill);
-		else _skill.removeSelf();
+		if (_skill.m.MSU.AddedStack == 1) return remove(_skill);
+		else return _skill.removeSelf();
 	}
 
 	local removeByID = o.removeByID;
@@ -91,8 +84,8 @@
 		local skill = this.getSkillByID(_skillID);
 		if (skill == null) return;
 
-		if (skill.m.MSU.AddedStack == 1) removeByID(_skillID);
-		else skill.removeSelf();
+		if (skill.m.MSU.AddedStack == 1) return removeByID(_skillID);
+		else return skill.removeSelf();
 	}
 
 	o.callSkillsFunction <- function( _function, _argsArray = null, _update = true, _aliveOnly = false )

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -51,8 +51,7 @@
 						}
 					}
 
-					if (alreadyPresentSkill.m.MSU_AddedStack > 1) alreadyPresentSkill.onRefresh();
-					else if (alreadyPresentSkill.m.MSU_AddedStack > 0)
+					if (alreadyPresentSkill.m.MSU_AddedStack > 0)
 					{
 						alreadyPresentSkill.m.IsGarbage = false;
 					}

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -27,6 +27,89 @@
 		this.m.ScheduledChangesSkills.clear();
 	}
 
+	local add = o.add;
+	o.add = function( _skill, _order = 0 )
+	{
+		if (!_skill.isStacking())
+		{
+			foreach (i, alreadyPresentSkill in this.m.Skills)
+			{
+				if (alreadyPresentSkill.getID() == _skill.getID())
+				{
+					alreadyPresentSkill.m.MSU_AddedStack += 1;
+					if (!::MSU.isNull(_skill.getItem()))
+					{
+						alreadyPresentSkill.setItem(_skill.getItem());
+						foreach (i, itemSkill in _skill.getItem().m.SkillPtrs)
+						{
+							if (itemSkill.getID() == _skill.getID())
+							{
+								_skill.getItem().m.SkillPtrs[i] = alreadyPresentSkill;
+								_skill.setItem(null);
+								break;
+							}
+						}
+					}
+
+					if (alreadyPresentSkill.m.MSU_AddedStack > 1) alreadyPresentSkill.onRefresh();
+					else if (alreadyPresentSkill.m.MSU_AddedStack > 0)
+					{
+						alreadyPresentSkill.m.IsGarbage = false;
+					}
+
+					return;
+				}
+			}
+
+			foreach (i, alreadyPresentSkill in this.m.SkillsToAdd)
+			{
+				if (alreadyPresentSkill.getID() == _skill.getID())
+				{
+					alreadyPresentSkill.m.MSU_AddedStack += 1;
+					if (!::MSU.isNull(_skill.getItem()))
+					{
+						alreadyPresentSkill.setItem(_skill.getItem());
+						foreach (i, itemSkill in _skill.getItem().m.SkillPtrs)
+						{
+							if (itemSkill.getID() == _skill.getID())
+							{
+								_skill.getItem().m.SkillPtrs[i] = alreadyPresentSkill;
+								_skill.setItem(null);
+								break;
+							}
+						}
+					}
+
+					if (alreadyPresentSkill.m.MSU_AddedStack > 0)
+					{
+						alreadyPresentSkill.m.IsGarbage = false;
+					}
+
+					return;
+				}
+			}
+		}
+
+		add(_skill, _order);
+	}
+
+	local remove = o.remove;
+	o.remove = function( _skill )
+	{
+		if (_skill.m.MSU_AddedStack == 1) remove(_skill);
+		else _skill.removeSelf();
+	}
+
+	local removeByID = o.removeByID;
+	o.removeByID = function( _skillID )
+	{
+		local skill = this.getSkillByID(_skillID);
+		if (skill == null) return;
+
+		if (skill.m.MSU_AddedStack == 1) this.removeByID(_skillID);
+		else skill.removeSelf();
+	}
+
 	o.callSkillsFunction <- function( _function, _argsArray = null, _update = true, _aliveOnly = false )
 	{
 		if (_argsArray == null) _argsArray = [null];

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -60,7 +60,10 @@
 				if (alreadyPresentSkill.getID() == _skill.getID())
 				{
 					incrementAddedStack(alreadyPresentSkill, _skill);
-					if (alreadyPresentSkill.m.MSU_AddedStack > 1) alreadyPresentSkill.onRefresh();
+					for (local i = 1; i < alreadyPresentSkill.m.MSU_AddedStack; i++)
+					{
+						alreadyPresentSkill.onRefresh();
+					}					
 					return;
 				}
 			}

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -32,43 +32,35 @@
 	{
 		if (_skill.isStacking()) return add(_skill, _order);
 
-		local incrementAddedStack = function( _alreadyPresentSkill, _skillToAdd )
-		{
-			if (++_alreadyPresentSkill.m.MSU.AddedStack > 0) _alreadyPresentSkill.m.IsGarbage = false;
+		local skills = clone this.m.Skills;
+		skills.extend(this.m.SkillsToAdd);
 
-			if (!::MSU.isNull(_skillToAdd.getItem()))
+		foreach (i, alreadyPresentSkill in skills)
+		{
+			if (alreadyPresentSkill.getID() == _skill.getID())
 			{
-				if (::MSU.isNull(_alreadyPresentSkill.getItem()) _alreadyPresentSkill.setItem(_skillToAdd.getItem());
-				foreach (i, itemSkill in _skillToAdd.getItem().m.SkillPtrs)
+				if (++alreadyPresentSkill.m.MSU.AddedStack > 0) alreadyPresentSkill.m.IsGarbage = false;
+
+				if (!::MSU.isNull(_skill.getItem()))
 				{
-					if (itemSkill.getID() == _skillToAdd.getID())
+					if (::MSU.isNull(alreadyPresentSkill.getItem()) alreadyPresentSkill.setItem(_skill.getItem());
+					foreach (j, itemSkill in _skill.getItem().m.SkillPtrs)
 					{
-						_skillToAdd.getItem().m.SkillPtrs[i] = _alreadyPresentSkill;
-						_skillToAdd.setItem(null);
-						break;
+						if (itemSkill.getID() == _skill.getID())
+						{
+							_skill.getItem().m.SkillPtrs[j] = alreadyPresentSkill;
+							_skill.setItem(null);
+							break;
+						}
 					}
 				}
-			}
-		}
 
-		foreach (alreadyPresentSkill in this.m.Skills)
-		{
-			if (alreadyPresentSkill.getID() == _skill.getID())
-			{
-				incrementAddedStack(alreadyPresentSkill, _skill);
-				if (alreadyPresentSkill.m.MSU.AddedStack > 1) alreadyPresentSkill.onRefresh();
+				if (alreadyPresentSkill.m.MSU.AddedStack > 1 && i < this.m.Skills.len()) alreadyPresentSkill.onRefresh();
 				return;
 			}
 		}
 
-		foreach (alreadyPresentSkill in this.m.SkillsToAdd)
-		{
-			if (alreadyPresentSkill.getID() == _skill.getID())
-			{
-				incrementAddedStack(alreadyPresentSkill, _skill);
-				return;
-			}
-		}
+		return add(_skill, _order);
 	}
 
 	local remove = o.remove;

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -41,6 +41,28 @@
 			{
 				if (++alreadyPresentSkill.m.MSU_AddedStack > 0) alreadyPresentSkill.m.IsGarbage = false;
 
+				foreach (fieldName, defaultValue in ::MSU.Skills.StackedFields)
+				{
+					// this.m.MSU_StackedFields is a table where each key is a fieldName and its value is a table
+					// this table's keys are the values of this.m[fieldName] and its values are how many times
+					// this value occurs in stacked additions e.g.
+					// 	this.m.MSU_StackedFields = {
+					// 		IsSerialized = {
+					// 			true = 1, // this skill was added 1 times with this.m.IsSerialized = true
+					// 			false = 3 // this skill was added 3 times with this.m.IsSerialized = false
+					// 		}
+					// 	}
+					if (!(fieldName in alreadyPresentSkill.m.MSU_StackedFields))
+					{
+						alreadyPresentSkill.m.MSU_StackedFields[fieldName] <- {};
+						alreadyPresentSkill.m.MSU_StackedFields[fieldName][defaultValue] <- 0;
+					}
+
+					local value = _skill.m[fieldName];
+					if (value in alreadyPresentSkill.m.MSU_StackedFields[fieldName]) alreadyPresentSkill.m.MSU_StackedFields[fieldName][value]++;
+					else alreadyPresentSkill.m.MSU_StackedFields[fieldName][value] <- 1;
+				}
+
 				if (!::MSU.isNull(_skill.getItem()))
 				{
 					if (::MSU.isNull(alreadyPresentSkill.getItem())) alreadyPresentSkill.setItem(_skill.getItem());

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -43,7 +43,7 @@
 
 				if (!::MSU.isNull(_skill.getItem()))
 				{
-					if (::MSU.isNull(alreadyPresentSkill.getItem()) alreadyPresentSkill.setItem(_skill.getItem());
+					if (::MSU.isNull(alreadyPresentSkill.getItem())) alreadyPresentSkill.setItem(_skill.getItem());
 					foreach (j, itemSkill in _skill.getItem().m.SkillPtrs)
 					{
 						if (itemSkill.getID() == _skill.getID())

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -30,7 +30,7 @@
 	local add = o.add;
 	o.add = function( _skill, _order = 0 )
 	{
-		if (_skill.isStacking()) return add(_skill, _order);
+		if (!_skill.isKeepingAddRemoveHistory()) return add(_skill, _order);
 
 		local skills = clone this.m.Skills;
 		skills.extend(this.m.SkillsToAdd);

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -37,7 +37,7 @@
 				_alreadyPresentSkill.m.MSU.AddedStack += 1;
 				if (!::MSU.isNull(_skillToAdd.getItem()))
 				{
-					_alreadyPresentSkill.setItem(_skillToAdd.getItem());
+					if (::MSU.isNull(_alreadyPresentSkill.getItem()) _alreadyPresentSkill.setItem(_skillToAdd.getItem());
 					foreach (i, itemSkill in _skillToAdd.getItem().m.SkillPtrs)
 					{
 						if (itemSkill.getID() == _skillToAdd.getID())

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -91,7 +91,7 @@
 		local skill = this.getSkillByID(_skillID);
 		if (skill == null) return;
 
-		if (skill.m.MSU_AddedStack == 1) this.removeByID(_skillID);
+		if (skill.m.MSU_AddedStack == 1) removeByID(_skillID);
 		else skill.removeSelf();
 	}
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -60,10 +60,7 @@
 				if (alreadyPresentSkill.getID() == _skill.getID())
 				{
 					incrementAddedStack(alreadyPresentSkill, _skill);
-					for (local i = 1; i < alreadyPresentSkill.m.MSU.AddedStack; i++)
-					{
-						alreadyPresentSkill.onRefresh();
-					}					
+					if (alreadyPresentSkill.m.MSU.AddedStack > 1) alreadyPresentSkill.onRefresh();
 					return;
 				}
 			}

--- a/msu/utils/skills.nut
+++ b/msu/utils/skills.nut
@@ -12,6 +12,9 @@
 		"MinRange",
 		"MaxRange"
 	],
+	StackedFields = {
+		IsSerialized = true
+	},
 
 	function addEvent( _name, _function = null, _update = true, _aliveOnly = false )
 	{


### PR DESCRIPTION
This solves several problems.

## Advantage 1:
As highlighted in #198, during game deserialization if multiple skills unequip or equip an item in their `onAdded` function, the skills of the item are not added to the character. This implementation in this PR does not suffer from that issue. (Vanilla bug report: http://battlebrothersgame.com/forums/topic/weapon-skills-lost-on-load-if-multiple-skills-call-unequip-and-equip-in-onadded/)

## Advantage 2:
Problem: The game does not keep track of how many things add the same non-stacking skill to the container, and therefore, only the first addition and the last removal count. This leads to convoluted cases. See the steps below:
1. Let's say a character has two perks: Juggernaut and Indomitable. Juggernaut perk adds the Indomitable active skill while holding a two-handed weapon. Indomitable perk adds the Indomitable active skill unconditionally. 
2. The character picks the Juggernaut perk first, then equips a two-handed weapon, then picks the Indomitable perk.
3. This results in Indomitable not adding the Indomitable active skill because the character already has it and it is a non-stacking skill.
4. The character unequips the weapon, this causes Juggernaut to remove the Indomitable active skill.
5. The character has now lost the Indomitable active skill even though he still has the Indomitable perk.

The examples above are for proving the point only. This can extend to many other similar cases e.g. let's say a perk adds the Riposte skill unconditionally. Riposte is also added by Swords. A character equips a Sword, then picks that perk, then unequips the Sword, resulting in losing the Riposte skill. And so on.

The implementation in this PR solves this issue by keeping track of how many skills have "stacked" the addition of a non-stacking perk. When a skill is removed, it lowers this stack by 1 and the skill is only removed from the character when the stack reaches 0.

## Advantage 3:
This is going to be especially important with the feature in #163 that adds onEquip and onUnequip functions for skills which I have used extensively to add/remove skills based on the type of weapon equipped and the perk the event is being called on. I often run into the issue highlighted in Advantage 2 and am very interested in ironing this out.

## How it works:
Every skill now has a `MSU_AddedStack` variable which keeps track of how many times this skill has been added/removed. If the number of additions is greater than the number of removals i.e. the `MSU_AddedStack` is greater than 0, it sets the `.m.IsGarbage` variable of the skill to `false` so that it isn't removed during `collectGarbage`. 

A special case is handled for skills added by items. Items hold references to the skill objects they add. In this new method, if a skill is being added by an item to a character who already has a skill with the same id, we will only update the existing skill's `MSU_AddedStack`. Therefore, it is important to update the item's `SkillPtrs` array to now point to that existing skill instead of the skill object the item was adding and similarly update the `.m.Item` variable of that skill to point to that item.