### PR TITLE
fix: add check that the values in both tables are tables instead of only in one table

### DIFF
--- a/scripts/config/msu/table.nut
+++ b/scripts/config/msu/table.nut
@@ -39,7 +39,7 @@
 			if (key in _table1)
 			{
 				if (!_overwrite) throw ::MSU.Exception.DuplicateKey(key);
-				if (typeof value == "table" && _recursively)
+				if (_recursively && typeof value == "table" && typeof _table1[key] == "table")
 				{
 					this.merge(_table1[key], value, true, true);
 					continue;


### PR DESCRIPTION
This fixes the issue where it was only checking for one value being table instead of both. This `_recursively` thing was added by @Enduriel and personally I still don't know if it should be included at all. The function is supposed to be an analogy to `array.extend` and that function doesn't do recursive extension either. What do you guys think?