### PR TITLE
feat: add onSkillsUpdated event for skills

### DIFF
--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -1,5 +1,5 @@
 ::mods_hookExactClass("entity/tactical/actor", function(o) {
-	o.m.MSU_callOnSkillsUpdated <- false;
+	o.m.MSU_isCallingOnSkillsUpdated <- true;
 
 	local onMovementStart = o.onMovementStart;
 	o.onMovementStart = function ( _tile, _numTiles )
@@ -38,8 +38,8 @@
 		onSkillsUpdated();
 		if (!this.m.IsDying)
 		{
-			this.m.MSU_callOnSkillsUpdated = !this.m.MSU_callOnSkillsUpdated;
-			if (this.m.MSU_callOnSkillsUpdated) this.getSkills().onSkillsUpdated();
+			this.m.MSU_isCallingOnSkillsUpdated = !this.m.MSU_isCallingOnSkillsUpdated;
+			if (!this.m.MSU_isCallingOnSkillsUpdated) this.getSkills().onSkillsUpdated();
 		}
 	}
 

--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -1,5 +1,7 @@
 ::mods_hookExactClass("entity/tactical/actor", function(o) {
-	o.m.MSU_isCallingOnSkillsUpdated <- true;
+	o.m.MSU <- {
+		IsCallingOnSkillsUpdated <- true
+	};
 
 	local onMovementStart = o.onMovementStart;
 	o.onMovementStart = function ( _tile, _numTiles )
@@ -38,8 +40,8 @@
 		onSkillsUpdated();
 		if (!this.m.IsDying)
 		{
-			this.m.MSU_isCallingOnSkillsUpdated = !this.m.MSU_isCallingOnSkillsUpdated;
-			if (!this.m.MSU_isCallingOnSkillsUpdated) this.getSkills().onSkillsUpdated();
+			this.m.MSU.IsCallingOnSkillsUpdated = !this.m.MSU.IsCallingOnSkillsUpdated;
+			if (!this.m.MSU.IsCallingOnSkillsUpdated) this.getSkills().onSkillsUpdated();
 		}
 	}
 

--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -1,4 +1,6 @@
 ::mods_hookExactClass("entity/tactical/actor", function(o) {
+	o.m.MSU_callOnSkillsUpdated <- false;
+
 	local onMovementStart = o.onMovementStart;
 	o.onMovementStart = function ( _tile, _numTiles )
 	{
@@ -28,6 +30,17 @@
 		}
 
 		return ret;
+	}
+
+	local onSkillsUpdated = o.onSkillsUpdated;
+	o.onSkillsUpdated = function()
+	{
+		onSkillsUpdated();
+		if (!this.m.IsDying)
+		{
+			this.m.MSU_callOnSkillsUpdated = !this.m.MSU_callOnSkillsUpdated;
+			if (this.m.MSU_callOnSkillsUpdated) this.getSkills().onSkillsUpdated();
+		}
 	}
 
 	local onDeath = o.onDeath;

--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -1,8 +1,4 @@
 ::mods_hookExactClass("entity/tactical/actor", function(o) {
-	o.m.MSU <- {
-		IsCallingOnSkillsUpdated = true
-	};
-
 	local onMovementStart = o.onMovementStart;
 	o.onMovementStart = function ( _tile, _numTiles )
 	{
@@ -32,17 +28,6 @@
 		}
 
 		return ret;
-	}
-
-	local onSkillsUpdated = o.onSkillsUpdated;
-	o.onSkillsUpdated = function()
-	{
-		onSkillsUpdated();
-		if (!this.m.IsDying)
-		{
-			this.m.MSU.IsCallingOnSkillsUpdated = !this.m.MSU.IsCallingOnSkillsUpdated;
-			if (!this.m.MSU.IsCallingOnSkillsUpdated) this.getSkills().onSkillsUpdated();
-		}
 	}
 
 	local onDeath = o.onDeath;

--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -1,6 +1,6 @@
 ::mods_hookExactClass("entity/tactical/actor", function(o) {
 	o.m.MSU <- {
-		IsCallingOnSkillsUpdated <- true
+		IsCallingOnSkillsUpdated = true
 	};
 
 	local onMovementStart = o.onMovementStart;

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -205,6 +205,10 @@
 		setFatigueCost(_f);
 	}
 
+	o.onSkillsUpdated <- function()
+	{
+	}
+
 	o.onMovementStarted <- function( _tile, _numTiles )
 	{
 	}

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -2,6 +2,7 @@
 	o.m.LastLevelOnUpdateLevelCalled <- 0;
 	o.m.ScheduledChangesSkills <- [];
 	o.m.IsPreviewing <- false;
+	o.m.IsCallingOnSkillsUpdated <- true;
 	o.PreviewProperty <- {};
 
 	local update = o.update;
@@ -25,6 +26,12 @@
 		}
 
 		this.m.ScheduledChangesSkills.clear();
+
+		if (!this.getActor().isDying())
+		{
+			this.m.IsCallingOnSkillsUpdated = !this.m.IsCallingOnSkillsUpdated;
+			if (!this.m.IsCallingOnSkillsUpdated) this.onSkillsUpdated();
+		}
 	}
 
 	o.callSkillsFunction <- function( _function, _argsArray = null, _update = true, _aliveOnly = false )

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -81,6 +81,11 @@
 		return _argsArray[_argsArray.len() - 1];
 	}
 
+	o.onSkillsUpdated <- function()
+	{
+		this.callSkillsFunction("onSkillsUpdated");
+	}
+
 	o.onMovementStarted <- function( _tile, _numTiles )
 	{
 		this.callSkillsFunction("onMovementStarted", [


### PR DESCRIPTION
This adds an event that is called at the end of `update()` after the `CurrentProperties` of the actor have been completely set up by the `update` function. It allows us to do things like the following:

```squirrel
// In some skill that is supposed to expire if the actor gets stunned
function onSkillsUpdated()
{
    if (this.getContainer().getActor().getCurrentProperties().IsStunned) this.removeSelf();
}
```
The above is currently impossible to do without hard coding like vanilla. Vanilla does it by using the `onAdded` function of the `Stunned` effect and any other effects e.g. `Horrified` that cause the character to be stunned and in that function they manually enter the ids of the skills that should be removed e.g. `effects.riposte`, `effects.spearwall` etc. This is very tightly coupled and very ugly for modders to try to mod - especially if a new status effect is added which also causes `IsStunned` in properties to be `true`.

The `MSU_callOnSkillsUpdated` variable is necessary because the `onSkillsUpdated` function of `actor` is called from within the skill container `update` function and because we call the `update` again at the end of the event, it will otherwise lead to infinite recursion.

Another thing it now enables is adding/removing skills during `onUpdate` and `onAfterUpdate` functions - as it triggers an update after the update.

The drawback of this is that it basically doubles the time of the `update` function (as it runs twice each time it is called now) - but I don't think that's practically a performance concern. An alternative, more efficient, implementation could be to instead have a `onAnySkillAdded( _skill )` function that is run after the `update` is run after a skill is added. However, this requires completely overwriting the vanilla `add` and `collectGarbage` functions of skill_container.