### PR TITLE
feat: add onQueryTileTooltip event for skills

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -254,6 +254,10 @@
 	{
 	}
 
+	o.onQueryTileTooltip <- function( _tile, _tooltip )
+	{
+	}
+
 	o.onQueryTooltip <- function( _skill, _tooltip )
 	{
 	}

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -152,6 +152,14 @@
 		], false);
 	}
 
+	o.onQueryTileTooltip <- function( _tile, _tooltip )
+	{
+		this.callSkillsFunction("onQueryTileTooltip", [
+			_tile,
+			_tooltip
+		], false);
+	}
+
 	o.onQueryTooltip <- function( _skill, _tooltip )
 	{
 		this.callSkillsFunction("onQueryTooltip", [

--- a/msu/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/msu/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -1,4 +1,15 @@
 ::mods_hookNewObjectOnce("ui/screens/tooltip/tooltip_events", function(o) {
+	local tactical_queryTileTooltipData = o.tactical_queryTileTooltipData;
+	o.tactical_queryTileTooltipData = function()
+	{
+		local ret = tactical_queryTileTooltipData();
+		if (ret != null && ::Tactical.TurnSequenceBar.getActiveEntity() != null && ::Tactical.TurnSequenceBar.getActiveEntity().isPlayerControlled())
+		{
+			::Tactical.TurnSequenceBar.getActiveEntity().getSkills().onQueryTileTooltip(::Tactical.State.getLastTileHovered(), ret);
+		}
+		return ret;
+	}
+
 	local general_querySkillTooltipData = o.general_querySkillTooltipData;
 	o.general_querySkillTooltipData = function( _entityId, _skillId )
 	{


### PR DESCRIPTION
Adds an event to skills that allows skills to modify the tile tooltip before it is displayed to keep such modifications nicely compartmentalized within skills (similar to onGetHitFactors and onQueryTooltip functions).