### PR TITLE
fix: add check to prevent slice on empty string

### DIFF
--- a/msu/hooks/items/weapons/weapon.nut
+++ b/msu/hooks/items/weapons/weapon.nut
@@ -127,7 +127,7 @@
 			}
 		}
 
-		this.m.Categories = this.m.Categories.slice(0, -1) + ", ";
+		if (this.m.Categories != "") this.m.Categories = this.m.Categories.slice(0, -1) + ", ";
 
 		if (this.isItemType(::Const.Items.ItemType.OneHanded))
 		{


### PR DESCRIPTION
I tested this fix ingame for a weapon.
Now you are able to have a Weapon with no weapontype (just one-handed or two-handed by themselves)
But more importantly: The game doesn't crash anymore if someone removes the last type of an item even if they give it another type right after.

Closes #211 