### PR TITLE
fix: range setting being unable to handle floats

### DIFF
--- a/msu/systems/mod_settings/mod_settings_system.nut
+++ b/msu/systems/mod_settings/mod_settings_system.nut
@@ -79,17 +79,24 @@
 		/*
 		_data = {
 			modID = {
-				settingID = value
+				settingID =
+				{
+					type,
+					value
+				}
 			}
 		}
 		*/
-
 		foreach (modID, panel in _data)
 		{
-			foreach (settingID, value in panel)
+			foreach (settingID, data in panel)
 			{
-				local setting = this.Panels[modID].getSetting(settingID);
-				setting.set(value);
+				this.updateSettingFromJS({
+					mod = modID,
+					id = settingID,
+					type = data.type,
+					value = data.value
+				});
 			}
 		}
 	}
@@ -117,6 +124,7 @@
 
 	function updateSettingFromJS( _data )
 	{
+		if (_data.type == "float") _data.value = _data.value.tofloat();
 		::getModSetting(_data.mod, _data.id).set(_data.value, false);
 	}
 

--- a/ui/mods/msu/mod_settings/range_setting.js
+++ b/ui/mods/msu/mod_settings/range_setting.js
@@ -1,5 +1,10 @@
 var RangeSetting = function (_mod, _page, _setting, _parentDiv)
 {
+	if (_setting.value % 1 != 0) _setting.value = parseFloat(_setting.value.toPrecision(6)); // fix for JS/Squirrel float conversion weirdness
+	if (_setting.min % 1 != 0) _setting.min = parseFloat(_setting.min.toPrecision(6));
+	if (_setting.max % 1 != 0) _setting.max = parseFloat(_setting.max.toPrecision(6));
+	if (_setting.step % 1 != 0) _setting.step = parseFloat(_setting.step.toPrecision(6));
+
 	this.data = _setting;
 	var self = this;
 	this.layout = $('<div class="setting-container range-container"/>');

--- a/ui/mods/msu/mod_settings/settings_screen.js
+++ b/ui/mods/msu/mod_settings/settings_screen.js
@@ -382,6 +382,20 @@ ModSettingsScreen.prototype.adjustTitles = function (self)
 	});
 }
 
+ModSettingsScreen.prototype.setTypeIfFloatOrInt = function ( _data )
+{
+	if (_data.type == "number")
+	{
+		if (_data.value % 1 == 0) _data.type = "integer";
+		else
+		{
+			_data.type = "float";
+			_data.value = _data.value.toPrecision(6);
+		}
+	}
+	return _data;
+}
+
 ModSettingsScreen.prototype.getChanges = function () // Could still be significantly improved/optimized
 {
 	var self = this;
@@ -393,7 +407,10 @@ ModSettingsScreen.prototype.getChanges = function () // Could still be significa
 		{
 			if ("IsSetting" in element.data && !element.locked && element.currentValue != element.value)
 			{
-				changes[_panelID][_elementID] = element.value;
+				changes[_panelID][_elementID] = self.setTypeIfFloatOrInt({
+					type : typeof element.value,
+					value : element.value
+				});
 			}
 		});
 	});
@@ -431,11 +448,13 @@ ModSettingsScreen.prototype.updateSetting = function (_setting)
 
 ModSettingsScreen.prototype.setModSettingValue = function (_modID, _settingID, _value)
 {
-	var out = {
+	var out = this.setTypeIfFloatOrInt({
 		mod : _modID,
+		type : typeof _value,
 		id : _settingID,
 		value : _value
-	};
+	});
+
 	this.updateSetting(out);
 	this.updateSettingInNut(out);
 };


### PR DESCRIPTION
All of this works fine from my testing and is in theory good as is. The limitation here is that we can only handle floats with up to 6 significant figures, and this isn't communicated to the modder in any way as it I'd have to write some sort of significant figure rounder for squirrel floats (doesn't exist in base squirrel or the vanilla math library) to check if the float passed has less than 6 significant figures.

It would also have to test if adding/removing step from min/max/value could lead to a value with more than 6 significant figures.

This is all possible, but quite complicated. For now I think this addresses one of the main known bugs we've had for a while and we should try and push this with 1.2 no matter what, with potentially working on parsing the input and informing the modder if they are passing unacceptable inputs later.

In practice this is very unlikely, the UI can't even really handle values of 3 significant figures assuming the full range is used with the highest level of granularity.