### PR TITLE
feat: add keybind to close popup when clicking escape

### DIFF
--- a/msu/msu_mod/load.nut
+++ b/msu/msu_mod/load.nut
@@ -6,3 +6,4 @@ includeFile("setup_msu_mod");
 includeFile("msu_mod_debug");
 includeFile("msu_mod_modsettings");
 includeFile("msu_tooltips");
+includeFile("msu_keybinds");

--- a/msu/msu_mod/msu_keybinds.nut
+++ b/msu/msu_mod/msu_keybinds.nut
@@ -1,0 +1,16 @@
+::MSU.Mod.Keybinds.addSQKeybind("ClosePopup", "escape", ::MSU.Key.State.All, function()
+{
+	if (::MSU.Popup.isVisible() && !::MSU.Popup.isAnimating())
+	{
+		if (::MSU.Popup.isForceQuitting())
+		{
+			::MSU.Popup.quitGame();
+		}
+		else
+		{
+			::MSU.Popup.hide();
+		}
+		return true;
+	}
+	return false;
+}, "Close MSU Popup");

--- a/scripts/mods/msu/popup.nut
+++ b/scripts/mods/msu/popup.nut
@@ -1,8 +1,20 @@
 this.popup <- {
 	m = {
+		Visible = false,
+		Animating = false,
 		JSHandle = null,
 		TextCache = "",
 		ForceQuit = false
+	}
+
+	function isVisible()
+	{
+		return this.m.Visible;
+	}
+
+	function isAnimating()
+	{
+		return this.m.Animating;
 	}
 
 	function showRawText( _text, _forceQuit = false )
@@ -28,6 +40,11 @@ this.popup <- {
 		this.m.ForceQuit = _bool;
 	}
 
+	function isForceQuitting()
+	{
+		return this.m.ForceQuit;
+	}
+
 	function connect()
 	{
 		this.m.JSHandle = ::UI.connect("MSUPopup", this);
@@ -38,8 +55,30 @@ this.popup <- {
 		}
 	}
 
+	function hide()
+	{
+		this.m.JSHandle.asyncCall("hide", null);
+	}
+
 	function quitGame()
 	{
 		// overwritten by mainMenuScreen hook, closes the game
+	}
+
+	function onScreenShown()
+	{
+		this.m.Visible = true;
+		this.m.Animating = false;
+	}
+
+	function onScreenHidden()
+	{
+		this.m.Visible = false;
+		this.m.Animating = false;
+	}
+
+	function onScreenAnimating()
+	{
+		this.m.Animating = true;
 	}
 };

--- a/ui/mods/msu/popup.js
+++ b/ui/mods/msu/popup.js
@@ -79,10 +79,12 @@ MSUPopup.prototype.show = function ()
 		easing: 'swing',
 		begin: function ()
 		{
+			self.notifyBackendOnAnimating();
 			$(this).removeClass('display-none').addClass('display-block');
 		},
 		complete: function ()
 		{
+			self.notifyBackendOnShown();
 		}
 	});
 }
@@ -121,9 +123,11 @@ MSUPopup.prototype.hide = function ()
 		easing: 'swing',
 		begin: function()
 		{
+			self.notifyBackendOnAnimating();
 		},
 		complete: function()
 		{
+			self.notifyBackendOnHidden();
 			$(this).css({ opacity: 0 });
 			$(this).removeClass('display-block').addClass('display-none');
 		}
@@ -146,5 +150,29 @@ MSUPopup.prototype.quitGame = function ()
 {
 	SQ.call(this.mSQHandle, "quitGame");
 }
+
+MSUPopup.prototype.notifyBackendOnShown = function ()
+{
+	if (this.mSQHandle !== null)
+	{
+		SQ.call(this.mSQHandle, 'onScreenShown');
+	}
+};
+
+MSUPopup.prototype.notifyBackendOnHidden = function ()
+{
+	if (this.mSQHandle !== null)
+	{
+		SQ.call(this.mSQHandle, 'onScreenHidden');
+	}
+};
+
+MSUPopup.prototype.notifyBackendOnAnimating = function ()
+{
+	if (this.mSQHandle !== null)
+	{
+		SQ.call(this.mSQHandle, 'onScreenAnimating');
+	}
+};
 
 registerScreen("MSUPopup", new MSUPopup());


### PR DESCRIPTION
This currently instead closes the game in the main menu if a popup appears, which is really annoying.
This also required the handling of `Animating` and `Visible` for popup, this code has effectively been cloned from `ui_screen.nut`