### PR TITLE
feat: add support for individuel ParagonLevel

### DIFF
--- a/msu/hooks/entity/tactical/player.nut
+++ b/msu/hooks/entity/tactical/player.nut
@@ -1,10 +1,48 @@
 ::mods_hookExactClass("entity/tactical/player", function(o) {
 	o.m.LevelUpsSpent <- 0;
+	o.m.ParagonLevel <- 11;
+
+    local oldCreate = o.create;
+    o.create = function()
+    {
+        oldCreate();
+        this.m.ParagonLevel = ::Const.XP.MaxLevelWithPerkpoints;  // Global default value in vanilla
+    }
 
 	o.getMovementSpeedMult <- function()
 	{
 		return 1.0;
 	}
+
+    local oldUpdateLevel = o.updateLevel;
+    o.updateLevel = function()
+    {
+        // Switcheroo of the global MaxLevel variable so that BB thinks that each brother may have a different maxlevel
+        local oldMaxLevelWithPerkpoints = ::Const.XP.MaxLevelWithPerkpoints;
+        ::Const.XP.MaxLevelWithPerkpoints = this.m.ParagonLevel;
+        oldUpdateLevel();
+        ::Const.XP.MaxLevelWithPerkpoints = oldMaxLevelWithPerkpoints;
+    }
+
+    local oldSetScenarioValues = o.setScenarioValues;
+    o.setScenarioValues = function()
+    {
+        // Switcheroo of the global MaxLevel variable so that BB thinks that each brother may have a different maxlevel
+        local oldMaxLevelWithPerkpoints = ::Const.XP.MaxLevelWithPerkpoints;
+        ::Const.XP.MaxLevelWithPerkpoints = this.m.ParagonLevel;
+        oldSetScenarioValues();
+        ::Const.XP.MaxLevelWithPerkpoints = oldMaxLevelWithPerkpoints;
+    }
+
+    local oldSetStartValuesEx = o.setStartValuesEx;
+    o.setStartValuesEx = function( _backgrounds, _addTraits = true )
+    {
+        // Switcheroo of the global MaxLevel variable so that BB thinks that each brother may have a different maxlevel
+        local oldMaxLevelWithPerkpoints = ::Const.XP.MaxLevelWithPerkpoints;
+        ::Const.XP.MaxLevelWithPerkpoints = this.m.ParagonLevel;
+        oldSetStartValuesEx( _backgrounds, _addTraits = true );
+        ::Const.XP.MaxLevelWithPerkpoints = oldMaxLevelWithPerkpoints;
+    }
 
 	local setAttributeLevelUpValues = o.setAttributeLevelUpValues;
 	o.setAttributeLevelUpValues = function( _v )

--- a/msu/hooks/states/world/asset_manager.nut
+++ b/msu/hooks/states/world/asset_manager.nut
@@ -22,6 +22,19 @@
 		update(_worldState);
 	}
 
+	// Manually fix the potentially wrong AttributeLevelUpValues for campaign bros
+	local oldSetCampaignSettings = o.setCampaignSettings;
+	o.setCampaignSettings = function( _settings )
+	{
+		oldSetCampaignSettings(_settings);
+
+		foreach( bro in ::World.getPlayerRoster().getAll() )
+		{
+			bro.m.Attributes = [];
+			bro.fillAttributeLevelUpValues(bro.m.ParagonLevel - 1);
+		}
+	}
+
 	o.getLastDayMorningEventCalled <- function()
 	{
 		return this.m.LastDayMorningEventCalled;

--- a/msu/hooks/ui/global/data_helper.nut
+++ b/msu/hooks/ui/global/data_helper.nut
@@ -1,0 +1,9 @@
+::mods_hookNewObject("ui/global/data_helper", function (o) {
+
+	local oldAddCharacterToUIData = o.addCharacterToUIData;
+	o.addCharacterToUIData = function( _entity, _target )
+	{
+		oldAddCharacterToUIData( _entity, _target );
+		_target.paragonLevel <- _entity.m.ParagonLevel;
+	}
+});

--- a/msu/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/msu/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -29,7 +29,7 @@
 			local statusEffect = entity.getSkills().getSkillByID(_statusEffectId);
 
 			if (statusEffect != null)
-			{	
+			{
 				local tooltip = statusEffect.getTooltip();
 				statusEffect.getContainer().onQueryTooltip(statusEffect, tooltip);
 				return tooltip;
@@ -49,6 +49,20 @@
 	o.general_queryUIElementTooltipData = function( _entityId, _elementId, _elementOwner )
 	{
 		local ret = general_queryUIElementTooltipData(_entityId, _elementId, _elementOwner);
+
+        // Paragon Level mention/overwrite
+        if(_elementId == "character-screen.left-panel-header-module.Experience" || _elementId == "character-screen.left-panel-header-module.Level")
+        {
+            foreach(entry in ret)
+            {
+                if (entry.id == 2 && entry.type == "description")
+                {
+                    entry.text = ::MSU.String.replace(entry.text, "11th character level, characters are veterans and", "paragon level " + ::Const.XP.MaxLevelWithPerkpoints + " characters")
+					break;
+				}
+            }
+        }
+
 		if (ret == null)
 		{
 			if (_elementId.find("msu-settings") == 0)

--- a/msu/ui/load.nut
+++ b/msu/ui/load.nut
@@ -7,6 +7,10 @@
 ::mods_registerJS("msu/ui_hooks/main_menu_screen.js");
 ::mods_registerJS("msu/ui_hooks/tooltip_module.js");
 
+// Paragon Level UI support
+::mods_registerJS("msu/ui_hooks/character_screen_left_panel_header_module.js");
+::mods_registerJS("msu/ui_hooks/character_screen_identifier.js");
+
 ::mods_registerJS("msu/backend_connection.js");
 ::mods_registerJS("msu/msu_connection.js");
 ::mods_registerJS("msu/ui_screen.js");

--- a/ui/mods/msu/ui_hooks/character_screen_identifier.js
+++ b/ui/mods/msu/ui_hooks/character_screen_identifier.js
@@ -1,0 +1,1 @@
+CharacterScreenIdentifier.Entity.Character.ParagonLevel = "paragonLevel";

--- a/ui/mods/msu/ui_hooks/character_screen_left_panel_header_module.js
+++ b/ui/mods/msu/ui_hooks/character_screen_left_panel_header_module.js
@@ -1,0 +1,18 @@
+var oldUpdateControls = CharacterScreenLeftPanelHeaderModule.prototype.updateControls;
+CharacterScreenLeftPanelHeaderModule.prototype.updateControls = function(_data)
+{
+    oldUpdateControls.call(this, _data);
+    if (_data === null || typeof(_data) !== 'object')
+	{
+		return;
+	}
+	if (!(CharacterScreenIdentifier.Entity.Character.ParagonLevel in _data)) return;
+    if (_data[CharacterScreenIdentifier.Entity.Character.Level] >= _data[CharacterScreenIdentifier.Entity.Character.ParagonLevel])
+	{
+		this.mXPProgressbar.addClass('xp-paragon');
+	}
+	else
+	{
+		this.mXPProgressbar.removeClass('xp-paragon');
+	}
+}


### PR DESCRIPTION
- new ParagonLevel variable for player.nut that defines when they stop gaining perks
- fix instances of hardcoded mention of the ParagonLevel in tooltip
- fix hardcoded ui coloring of ParagonLevel
- Closes #218 