### PR TITLE
fix(vanilla): fix skills sometimes not being added properly

### DIFF
--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -34,6 +34,25 @@
 		}
 	}
 
+	// VANILLAFIX http://battlebrothersgame.com/forums/topic/weapon-skills-lost-on-load-if-multiple-skills-call-unequip-and-equip-in-onadded
+	// if we overwrite add later, we should do this inside the loop in the function
+	local add = o.add;
+	o.add = function( _skill, _order = 0 )
+	{
+		if (!_skill.isStacking())
+		{
+			foreach (skill in this.m.SkillsToAdd)
+			{
+				if (_skill.getID() == skill.getID() && skill.isGarbage())
+				{
+					this.m.SkillsToAdd.remove(skill);
+					break;
+				}
+			}
+		}
+		return add(_skill, _order);
+	}
+
 	o.callSkillsFunction <- function( _function, _argsArray = null, _update = true, _aliveOnly = false )
 	{
 		if (_argsArray == null) _argsArray = [null];


### PR DESCRIPTION
The scenario where this could occur is outlined here http://battlebrothersgame.com/forums/topic/weapon-skills-lost-on-load-if-multiple-skills-call-unequip-and-equip-in-onadded.

This is a nicer alternative to #198. 