### PR TITLE
refactor: move mod settings serialization to serialization system

### DIFF
--- a/msu/hooks/states/world_state.nut
+++ b/msu/hooks/states/world_state.nut
@@ -288,10 +288,9 @@
 	local onSerialize = o.onSerialize;
 	o.onSerialize = function( _out )
 	{
-		::MSU.System.ModSettings.flagSerialize();
+		::MSU.System.ModSettings.flagSerialize(_out);
 		::World.Flags.set("MSU.LastDayMorningEventCalled", ::World.Assets.getLastDayMorningEventCalled());
 		onSerialize(_out);
-		::MSU.System.ModSettings.resetFlags();
 		::MSU.System.Serialization.clearFlags();
 	}
 
@@ -307,9 +306,7 @@
 		{
 			::World.Assets.setLastDayMorningEventCalled(::World.getTime().Days);
 		}
-
-		::MSU.System.ModSettings.flagDeserialize();
-		::MSU.System.ModSettings.resetFlags(); // should probably get refactored into Serialization at some point
+		::MSU.System.ModSettings.flagDeserialize(_in);
 		::MSU.System.Serialization.clearFlags();
 	}
 

--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -193,7 +193,7 @@
 			local valueFlag = getPropertyFlag(modID, "Value");
 			if (::World.Flags.has(valueFlag) && ::World.Flags.get(valueFlag) != null + "")
 			{
-				this.set(::World.Flags.get(valueFlag), true, false, true);
+				this.set(::World.Flags.get(valueFlag), true, false);
 			}
 		}
 		else

--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -147,67 +147,61 @@
 		return ret;
 	}
 
-	function getSerDeFlag( _modID )
+	function __getSerializationTable()
 	{
-		return "ModSetting." + _modID + "." + this.getID();
+		return {
+			Value = this.Value,
+			Locked = this.Locked,
+			LockReason = this.LockReason
+		};
 	}
 
-	function getPropertyFlag( _modID, _property )
+	function __setFromSerializationTable( _table )
 	{
-		return this.getSerDeFlag(_modID) + "." + _property;
+		this.Value = _table.Value;
+		this.Locked = _table.Locked;
+		this.LockReason = _table.LockReason;
 	}
 
-	function setFlagForProperty( _property, _modID )
+	function flagSerialize( _out )
 	{
-		::World.Flags.set(this.getPropertyFlag(_modID, _property), this[_property]);
+		::MSU.Mod.Serialization.flagSerialize("MS." + this.getMod().getID() + "." + this.getID(), this.__getSerializationTable()); // not sure I like this ID generation, MS is short for ModSettings to save space
 	}
 
-	function setPropertyIfFlagExists( _property, _modID )
+	function flagDeserialize( _in )
 	{
-		local flag = this.getPropertyFlag(_modID, _property);
-		if (::World.Flags.has(flag))
+		if (::MSU.Mod.Serialization.isSavedVersionAtLeast("1.2.0", _in.getMetaData()))
 		{
-			this[_property] = ::World.Flags.get(flag);
+			this.__setFromSerializationTable(::MSU.Mod.Serialization.flagDeserialize("MS." + this.getMod().getID() + "." + this.getID()));
 		}
-	}
-
-	function clearFlagForProperty( _property, _modID )
-	{
-		local flag = this.getPropertyFlag(_modID, _property);
-		if (::World.Flags.has(flag))
+		else if (::MSU.Mod.Serialization.isSavedVersionAtLeast("0.0.1", _in.getMetaData()))
 		{
-			::World.Flags.remove(flag);
+			local getPropertyFlag = @( _modID, _property ) "ModSetting." + _modID + "." + this.getID() + "." + _property;
+			local function setPropertyIfFlagExists( _property, _modID )
+			{
+				local flag = getPropertyFlag(_modID, _property);
+				if (::World.Flags.has(flag))
+				{
+					this[_property] = ::World.Flags.get(flag);
+					::World.Flags.remove(flag);
+				}
+			}
+			local modID = this.getMod().getID();
+			setPropertyIfFlagExists("Locked", modID);
+			setPropertyIfFlagExists("LockReason", modID);
+
+			local valueFlag = getPropertyFlag(modID, "Value");
+			if (::World.Flags.has(valueFlag) && ::World.Flags.get(valueFlag) != "(null : 0x00000000)")
+			{
+				this.set(::World.Flags.get(valueFlag), true, false, true);
+			}
 		}
-	}
-
-
-	function flagSerialize()
-	{
-		local modID = this.getMod().getID();
-		this.setFlagForProperty("Value", modID);
-		this.setFlagForProperty("Locked", modID);
-		this.setFlagForProperty("LockReason", modID);
-	}
-
-	function flagDeserialize()
-	{
-		local modID = this.getMod().getID();
-		this.setPropertyIfFlagExists("Locked", modID);
-		this.setPropertyIfFlagExists("LockReason", modID);
-
-		local valueFlag = this.getPropertyFlag(modID, "Value");
-		if (::World.Flags.has(valueFlag) && ::World.Flags.get(valueFlag) != "(null : 0x00000000)")
+		else
 		{
-			this.set(::World.Flags.get(valueFlag), true, false, true);
+			// This is what runs when we load a vanilla game, leaving this as placeholder for now
+			// I think we should consider resetting the value here, (we should definitely reset once we have persistent data working with cookies)
+			// as while it is less convenient, not resetting could theoretically cause issues.
 		}
-	}
-
-	function resetFlags()
-	{
-		local modID = this.getMod().getID();
-		this.clearFlagForProperty("Value", modID);
-		this.clearFlagForProperty("Locked", modID);
-		this.clearFlagForProperty("LockReason", modID);
 	}
 
 	function tostring()

--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -191,7 +191,7 @@
 			setPropertyIfFlagExists("LockReason", modID);
 
 			local valueFlag = getPropertyFlag(modID, "Value");
-			if (::World.Flags.has(valueFlag) && ::World.Flags.get(valueFlag) != "(null : 0x00000000)")
+			if (::World.Flags.has(valueFlag) && ::World.Flags.get(valueFlag) != null + "")
 			{
 				this.set(::World.Flags.get(valueFlag), true, false, true);
 			}

--- a/msu/systems/mod_settings/elements/enum_setting.nut
+++ b/msu/systems/mod_settings/elements/enum_setting.nut
@@ -31,9 +31,9 @@
 		return ret;
 	}
 
-	function flagDeserialize()
+	function flagDeserialize( _in )
 	{
-		base.flagDeserialize();
+		base.flagDeserialize(_in);
 		if (this.Array.find(this.Value) == null)
 		{
 			::logError("Value \'" + this.Value + "\' not contained in array for setting " + this.getID() + " in mod " + this.getMod().getID());

--- a/msu/systems/mod_settings/mod_settings_system.nut
+++ b/msu/systems/mod_settings/mod_settings_system.nut
@@ -133,14 +133,14 @@
 		this.Screen.updateSettingInJS( _modID, _settingID, _value );
 	}
 
-	function callPanelsFunction( _function, ... )
+	function callPanelsFunction( _function, _argsArray )
 	{
-		vargv.insert(0, null);
+		_argsArray.insert(0, null);
 
 		foreach (panel in this.Panels)
 		{
-			vargv[0] = panel;
-			panel[_function].acall(vargv);
+			_argsArray[0] = panel;
+			panel[_function].acall(_argsArray);
 		}
 	}
 
@@ -149,19 +149,14 @@
 		::MSU.System.PersistentData.loadFileForEveryMod("ModSetting");
 	}
 
-	function flagSerialize()
+	function flagSerialize( _out )
 	{
-		this.callPanelsFunction("flagSerialize");
+		this.callPanelsFunction("flagSerialize", [_out]);
 	}
 
-	function resetFlags()
+	function flagDeserialize( _in )
 	{
-		this.callPanelsFunction("resetFlags");
-	}
-
-	function flagDeserialize()
-	{
-		this.callPanelsFunction("flagDeserialize");
+		this.callPanelsFunction("flagDeserialize", [_in]);
 	}
 
 	function getUIData( _flags = null )

--- a/msu/systems/mod_settings/settings_panel.nut
+++ b/msu/systems/mod_settings/settings_panel.nut
@@ -140,35 +140,30 @@
 		return this.Mod.getID();
 	}
 
-	function callSettingsFunction( _function, ... )
+	function callSettingsFunction( _function, _argsArray )
 	{
-		vargv.insert(0, null);
+		_argsArray.insert(0, null);
 		foreach (page in this.Pages)
 		{
 			foreach (setting in page.getSettings())
 			{
 				if (setting instanceof ::MSU.Class.AbstractSetting)
 				{
-					vargv[0] = setting;
-					setting[_function].acall(vargv);
+					_argsArray[0] = setting;
+					setting[_function].acall(_argsArray);
 				}
 			}
 		}
 	}
 
-	function flagSerialize()
+	function flagSerialize( _out )
 	{
-		this.callSettingsFunction("flagSerialize");
+		this.callSettingsFunction("flagSerialize", [_out]);
 	}
 
-	function flagDeserialize()
+	function flagDeserialize( _in )
 	{
-		this.callSettingsFunction("flagDeserialize");
-	}
-
-	function resetFlags()
-	{
-		this.callSettingsFunction("resetFlags");
+		this.callSettingsFunction("flagDeserialize", [_in]);
 	}
 
 	function getUIData( _flags = [] )


### PR DESCRIPTION
currently requires that the local version is bumped up to 1.2.0, and will not load properly otherwise.

Now that we have a standardized implementation of flagSerialization, this commit removes the old custom setup for ModSettings, and instead makes the system rely on the Serialization System's new additions