### PR TITLE
Split Settings callback into callbacks for Before and After the value was changed

### DIFF
--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -5,7 +5,8 @@
 	BaseValue = null;
 	Locked = null;
 	LockReason = null;
-	Callbacks = null;
+	BeforeChangeCallbacks = null;
+	AfterChangeCallbacks = null;
 	Persistence = null; //if it should print change to log for further manipulation
 
 	constructor( _id, _value, _name = null, _description = null )
@@ -16,7 +17,8 @@
 		this.Locked = false;
 		this.LockReason = "";
 		this.Persistence = true;
-		this.Callbacks = [];
+		this.BeforeChangeCallbacks = [];
+		this.AfterChangeCallbacks = [];
 		this.Data.IsSetting <- true;
 	}
 
@@ -40,17 +42,30 @@
 		::MSU.System.PersistentData.writeToLog(_tag, this.getMod().getID(), [this.getID(), payload]);
 	}
 
-	function onChangedCallback( _newValue )
+	function onBeforeChangeCallback( _newValue )
 	{
-		foreach (callback in this.Callbacks)
+		foreach (callback in this.BeforeChangeCallbacks)
 		{
 			callback.call(this, _newValue);
 		}
 	}
 
-	function addCallback( _callback )
+	function onAfterChangeCallback( _oldValue )
 	{
-		this.Callbacks.push(_callback);
+		foreach (callback in this.AfterChangeCallbacks)
+		{
+			callback.call(this, _oldValue);
+		}
+	}
+
+	function addBeforeChangeCallback( _callback )
+	{
+		this.BeforeChangeCallbacks.push(_callback);
+	}
+
+	function addAfterChangeCallback( _callback )
+	{
+		this.AfterChangeCallbacks.push(_callback);
 	}
 
 	function reset()
@@ -64,7 +79,7 @@
 		this.set(_value, _updateJS, _updatePersistence, _updateCallback, _force);
 	}
 
-	function set( _value, _updateJS = true, _updatePersistence = true, _updateCallback = true, _force = false)
+	function set( _newValue, _updateJS = true, _updatePersistence = true, _updateBeforeChangeCallback = true, _force = false, _updateAfterChangeCallback = true)
 	{
 		if (this.Locked)
 		{
@@ -72,20 +87,25 @@
 			return false;
 		}
 
-		if (_value != this.Value || _force)
+		if (_newValue != this.Value || _force)
 		{
-			if (_updateCallback)
+			local oldValue = this.Value;
+			if (_updateBeforeChangeCallback)
 			{
-				this.onChangedCallback(_value);
+				this.onBeforeChangeCallback(_newValue);
 			}
-			this.Value = _value;
+			this.Value = _newValue;
+			if (_updateAfterChangeCallback)
+			{
+				this.onAfterChangeCallback(oldValue);
+			}
 			if (_updatePersistence && this.Persistence)
 			{
 				this.printForParser();
 			}
 			if (_updateJS)
 			{
-				::MSU.System.ModSettings.updateSettingInJS(this.getPanelID(), this.getID(), _value);
+				::MSU.System.ModSettings.updateSettingInJS(this.getPanelID(), this.getID(), _newValue);
 			}
 		}
 
@@ -218,5 +238,11 @@
 	function _tostring()
 	{
 		return this.tostring();
+	}
+
+	// Deprecated
+	function addCallback( _callback )
+	{
+		this.addBeforeChangeCallback(_callback);
 	}
 }

--- a/msu/systems/mod_settings/elements/boolean_setting.nut
+++ b/msu/systems/mod_settings/elements/boolean_setting.nut
@@ -8,9 +8,9 @@
 		base.constructor(_id, _value, _name, _description);
 	}
 
-	function set( _value, _updateJS = true, _updatePersistence = true, _updateCallback = true, _force = true )
+	function set( _newValue, _updateJS = true, _updatePersistence = true, _updateBeforeChangeCallback = true, _force = true, _updateAfterChangeCallback = true)
 	{
-		::MSU.requireBool(_value);
-		return base.set(_value, _updateJS, _updatePersistence, _updateCallback, _force);
+		::MSU.requireBool(_newValue);
+		return base.set(_newValue, _updateJS, _updatePersistence, _updateBeforeChangeCallback, _force, _updateAfterChangeCallback);
 	}
 }

--- a/msu/systems/mod_settings/elements/button_setting.nut
+++ b/msu/systems/mod_settings/elements/button_setting.nut
@@ -4,7 +4,7 @@
 
 	function onPressedCallback()
 	{
-		foreach (callback in this.Callbacks)
+		foreach (callback in this.BeforeChangeCallbacks)
 		{
 			callback.call(this);
 		}

--- a/msu/systems/mod_settings/elements/string_setting.nut
+++ b/msu/systems/mod_settings/elements/string_setting.nut
@@ -8,9 +8,9 @@
 		base.constructor(_id, _value, _name, _description);
 	}
 
-	function set( _value, _updateJS = true, _updatePersistence = true, _updateCallback = true, _force = true )
+	function set( _newValue, _updateJS = true, _updatePersistence = true, _updateBeforeChangeCallback = true, _force = true, _updateAfterChangeCallback = true)
 	{
-		::MSU.requireString(_value);
-		return base.set(_value, _updateJS, _updatePersistence, _updateCallback, _force);
+		::MSU.requireString(_newValue);
+		return base.set(_newValue, _updateJS, _updatePersistence, _updateBeforeChangeCallback, _force, _updateAfterChangeCallback);
 	}
 }


### PR DESCRIPTION
Originally, the callbacks ran before the value was changed, passing the new value.  This was not very convenient in practice. With this PR, the user can decide whether to run the callback before or after a change. The new value gets passed in BeforeChange callbacks, the old value in AfterChange callbacks.