### PR TITLE
Simplify setBaseValue function

### DIFF
--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -58,10 +58,13 @@
 		this.set(this.BaseValue, true, true, true, true);
 	}
 
-	function setBaseValue( _value, _updateJS = true, _updatePersistence = true, _updateCallback = true, _force = false )
+	function setBaseValue( _value, _reset = false)
 	{
 		this.m.BaseValue = _value;
-		this.set(_value, _updateJS, _updatePersistence, _updateCallback, _force);
+		if (_reset)
+		{
+			this.reset();
+		}
 	}
 
 	function set( _value, _updateJS = true, _updatePersistence = true, _updateCallback = true, _force = false)


### PR DESCRIPTION
With the new reset() functionality, this is a much cleaner way of achieving the same thing. This function was undocumented, so it can be a breaking change.