### PR TITLE
Simplify keybind settings by offloading the actual settings functionality to the modsettings system

### DIFF
--- a/msu/hooks/states/root_state.nut
+++ b/msu/hooks/states/root_state.nut
@@ -1,5 +1,5 @@
 ::mods_addHook("root_state.onInit", function(r) // executed once per game session
 {
-	::MSU.System.ModSettings.importPersistentSettings();
 	::MSU.System.Keybinds.importPersistentSettings();
+	::MSU.System.ModSettings.importPersistentSettings();
 });

--- a/msu/systems/keybinds/abstract_keybind.nut
+++ b/msu/systems/keybinds/abstract_keybind.nut
@@ -63,9 +63,9 @@
 	{
 		local setting = ::MSU.Class.KeybindSetting(this.getID(), this.getKeyCombinations(), this.getName());
 		setting.setDescription(this.getDescription());
-		setting.addCallback(function(_data)
+		setting.addAfterChangeCallback(function(_oldValue)
 		{
-			::MSU.System.Keybinds.update(this.getMod().getID(), this.getID(), _data, true, false, false);
+			::MSU.System.Keybinds.update(this.getMod().getID(), this.getID());
 		});
 		return setting;
 	}

--- a/msu/systems/keybinds/keybinds_mod_addon.nut
+++ b/msu/systems/keybinds/keybinds_mod_addon.nut
@@ -1,15 +1,5 @@
 ::MSU.Class.KeybindsModAddon <- class extends ::MSU.Class.SystemModAddon
 {
-	function update( _id, _keyCombinations )
-	{
-		::MSU.System.Keybinds.update(this.Mod.getID(), _id, _keyCombinations, true, false, false);
-	}
-
-	function updateBaseValue( _id, _keyCombinations )
-	{
-		::MSU.System.Keybinds.updateBaseValue(this.Mod.getID(), _id, _keyCombinations, true, false, false);
-	}
-
 	function addSQKeybind( _id, _keyCombinations, _state, _function, _name = null, _keyState = null, _description = "" )
 	{
 		local keybind = ::MSU.Class.KeybindSQ(this.Mod.getID(), _id, _keyCombinations, _state, _function, _name, _keyState);
@@ -44,5 +34,17 @@
 	function addTitle( _id, _name )
 	{
 		::MSU.System.ModSettings.getPanel(this.Mod.getID()).getPage("Keybinds").addTitle(_id, _name);
+	}
+
+	// Deprecated, use ModSettings set() instead
+	function update( _id, _keyCombinations )
+	{
+		::MSU.System.ModSettings.getPanel(this.Mod.getID()).getSetting(_id).set(_keyCombinations);
+	}
+
+	// Deprecated, use ModSettings setBaseValue() instead
+	function updateBaseValue( _id, _keyCombinations)
+	{
+		::MSU.System.Keybinds.updateBaseValue(this.Mod.getID(), _id, _keyCombinations);
 	}
 }

--- a/msu/systems/keybinds/keybinds_mod_addon.nut
+++ b/msu/systems/keybinds/keybinds_mod_addon.nut
@@ -41,10 +41,4 @@
 	{
 		::MSU.System.ModSettings.getPanel(this.Mod.getID()).getSetting(_id).set(_keyCombinations);
 	}
-
-	// Deprecated, use ModSettings setBaseValue() instead
-	function updateBaseValue( _id, _keyCombinations)
-	{
-		::MSU.System.Keybinds.updateBaseValue(this.Mod.getID(), _id, _keyCombinations);
-	}
 }

--- a/msu/systems/keybinds/keybinds_system.nut
+++ b/msu/systems/keybinds/keybinds_system.nut
@@ -90,7 +90,7 @@
 		return keybind;
 	}
 
-	function update( _modID, _id)
+	function update( _modID, _id )
 	{
 		local keybind = this.remove(_modID, _id);
 		keybind.KeyCombinations = split(::MSU.Key.sortKeyCombinationsString(::getModSetting(_modID, _id).getValue()), "/");
@@ -172,7 +172,7 @@
 		return this.onInput(_key, _environment, _state, keyAsString, keyState);
 	}
 
-	function frameUpdate( _ = null) # needs an empty default parameter since scheduleEvent uses .call(_env)
+	function frameUpdate( _ = null ) # needs an empty default parameter since scheduleEvent uses .call(_env)
 	{
 		if (!this.KeysChanged && this.PressedKeys.len() != 0)
 		{

--- a/msu/systems/keybinds/keybinds_system.nut
+++ b/msu/systems/keybinds/keybinds_system.nut
@@ -90,11 +90,10 @@
 		return keybind;
 	}
 
-	function update( _modID, _id, _keyCombinations, _updateJS = true, _updatePersistence = true, _updateCallback = true )
+	function update( _modID, _id)
 	{
 		local keybind = this.remove(_modID, _id);
-		keybind.KeyCombinations = split(::MSU.Key.sortKeyCombinationsString(_keyCombinations),"/");
-		::getModSetting(_modID, _id).set(keybind.getKeyCombinations(), _updateJS, _updatePersistence, _updateCallback);
+		keybind.KeyCombinations = split(::MSU.Key.sortKeyCombinationsString(::getModSetting(_modID, _id).getValue()), "/");
 		this.add(keybind, false);
 	}
 
@@ -104,16 +103,6 @@
 		keybind.KeyCombinations = split(::MSU.Key.sortKeyCombinationsString(_keyCombinations),"/");
 		::getModSetting(_modID, _id).setBaseValue(keybind.getKeyCombinations(), _updateJS, _updatePersistence, _updateCallback, true);
 		this.add(keybind, false);
-	}
-
-	function updateFromPersistence( _modID, _id, _keyCombinations )
-	{
-		if(!(_modID in this.KeybindsByMod))
-		{
-			::logError(format("Trying to update keybind %s for mod %s but mod does not exist!"), _id, _modID);
-			return;
-		}
-		this.update(_modID, _id, _keyCombinations, true, false, false);
 	}
 
 	function call( _key, _environment, _state, _keyState )
@@ -271,5 +260,11 @@
 	function importPersistentSettings()
 	{
 		::MSU.System.PersistentData.loadFileForEveryMod("Keybind");
+	}
+
+	// Deprecated, now handled over the mod settings system
+	function updateFromPersistence( _modID, _id, _keyCombinations )
+	{
+		this.MSU.System.ModSettings.setSettingFromPersistence(_modID, _id, _keyCombinations);
 	}
 }

--- a/msu/systems/keybinds/keybinds_system.nut
+++ b/msu/systems/keybinds/keybinds_system.nut
@@ -259,10 +259,4 @@
 	{
 		this.MSU.System.ModSettings.setSettingFromPersistence(_modID, _id, _keyCombinations);
 	}
-
-	// Deprecated, now handled over the mod settings system
-	function updateBaseValue( _modID, _id, _keyCombinations, _updateJS = true, _updatePersistence = true, _updateCallback = true )
-	{
-		::getModSetting(_modID, _id).setBaseValue(_keyCombinations);
-	}
 }

--- a/msu/systems/keybinds/keybinds_system.nut
+++ b/msu/systems/keybinds/keybinds_system.nut
@@ -97,14 +97,6 @@
 		this.add(keybind, false);
 	}
 
-	function updateBaseValue( _modID, _id, _keyCombinations, _updateJS = true, _updatePersistence = true, _updateCallback = true )
-	{
-		local keybind = this.remove(_modID, _id);
-		keybind.KeyCombinations = split(::MSU.Key.sortKeyCombinationsString(_keyCombinations),"/");
-		::getModSetting(_modID, _id).setBaseValue(keybind.getKeyCombinations(), _updateJS, _updatePersistence, _updateCallback, true);
-		this.add(keybind, false);
-	}
-
 	function call( _key, _environment, _state, _keyState )
 	{
 		if (!(_key in this.KeybindsByKey))
@@ -266,5 +258,11 @@
 	function updateFromPersistence( _modID, _id, _keyCombinations )
 	{
 		this.MSU.System.ModSettings.setSettingFromPersistence(_modID, _id, _keyCombinations);
+	}
+
+	// Deprecated, now handled over the mod settings system
+	function updateBaseValue( _modID, _id, _keyCombinations, _updateJS = true, _updatePersistence = true, _updateCallback = true )
+	{
+		::getModSetting(_modID, _id).setBaseValue(_keyCombinations);
 	}
 }

--- a/msu/systems/mod_settings/elements/keybind_setting.nut
+++ b/msu/systems/mod_settings/elements/keybind_setting.nut
@@ -1,10 +1,4 @@
 ::MSU.Class.KeybindSetting <- class extends ::MSU.Class.StringSetting
 {
 	static Type = "Keybind";
-	// Maybe add a keybind combination validator at some point
-
-	function printForParser()
-	{
-		base.printForParser(this.Type);
-	}
 }


### PR DESCRIPTION
This depends on #235 .
This simplifies some aspects of the Keybinds system by making the Modsettings system entirely responsible for setting values, while they are only fetched directly from the setting. Persistent data is now also handled entirely over Modsettings. Concerns are further separated and the code is easier to read and maintain.