### PR TITLE
feat: kwargs arguments MSU.Table function

### DIFF
--- a/scripts/config/msu/table.nut
+++ b/scripts/config/msu/table.nut
@@ -1,6 +1,6 @@
 ::MSU.Table <- {
 
-	function getKwargsTable(_options, _delegate)
+	function getKwargsTable( _options, _delegate )
 	{
 		if (_options == null)
 			_options = {};

--- a/scripts/config/msu/table.nut
+++ b/scripts/config/msu/table.nut
@@ -1,11 +1,11 @@
 ::MSU.Table <- {
 
-	function getKwargsTable( _options, _defaultArgumentTable )
+	function getKwargsTable( _passedArguments, _defaultArgumentsTable )
 	{
-		if (_options == null)
-			_options = {};
-		_options.setdelegate(_defaultArgumentTable);
-		return _options;
+		if (_passedArguments == null)
+			_passedArguments = {};
+		_passedArguments.setdelegate(_defaultArgumentsTable);
+		return _passedArguments;
 	}
 
 	function rand( _table )

--- a/scripts/config/msu/table.nut
+++ b/scripts/config/msu/table.nut
@@ -1,6 +1,6 @@
 ::MSU.Table <- {
 
-	function getKwargsTable( _passedArguments, _defaultArgumentsTable )
+	function kwargs( _passedArguments, _defaultArgumentsTable )
 	{
 		if (_passedArguments == null)
 			_passedArguments = {};

--- a/scripts/config/msu/table.nut
+++ b/scripts/config/msu/table.nut
@@ -1,10 +1,10 @@
 ::MSU.Table <- {
 
-	function getKwargsTable( _options, _delegate )
+	function getKwargsTable( _options, _defaultArgumentTable )
 	{
 		if (_options == null)
 			_options = {};
-		_options.setdelegate(_delegate);
+		_options.setdelegate(_defaultArgumentTable);
 		return _options;
 	}
 

--- a/scripts/config/msu/table.nut
+++ b/scripts/config/msu/table.nut
@@ -1,4 +1,13 @@
 ::MSU.Table <- {
+
+	function getKwargsTable(_options, _delegate)
+	{
+		if (_options == null)
+			_options = {};
+		_options.setdelegate(_delegate);
+		return _options;
+	}
+
 	function rand( _table )
 	{
 		local chosenIdx = ::Math.rand(0, _table.len() - 1);


### PR DESCRIPTION
This adds a function to get a key word arguments table that employs delegation. The goal is to allow for easier handling of large numbers of arguments where ordering might become cumbersome. Due to the delegation, `this` will first refer to the passed options, and then to the passed 'default' arguments.