### PR TITLE
Stack based behavior addition removal

### DIFF
--- a/msu/hooks/ai/tactical/agent.nut
+++ b/msu/hooks/ai/tactical/agent.nut
@@ -1,0 +1,33 @@
+::mods_hookBaseClass("ai/tactical/agent", function(o) {
+	o = o[o.SuperName];
+
+	o.m.MSU_BehaviorStacks <- {};
+
+	local addBehavior = o.addBehavior;
+	o.addBehavior = function( _behavior )
+	{
+		if (_behavior.getID() in this.m.MSU_BehaviorStacks)
+		{
+			++this.m.MSU_BehaviorStacks[_behavior.getID()];
+			return;
+		}
+
+		this.m.MSU_BehaviorStacks[_behavior.getID()] <- 1;
+		return addBehavior(_behavior);
+	}
+
+	local removeBehavior = o.removeBehavior;
+	o.removeBehavior = function( _id )
+	{
+		if (_id in this.m.MSU_BehaviorStacks) delete this.m.MSU_BehaviorStacks[_id];
+		return removeBehavior(_id);
+	}
+
+	// TODO: This function's name is temporary and is currently undocumented while we search for a better name
+	// Once we find a better name we will change it and add it to documentation
+	o.removeBehaviorByStack <- function( _id )
+	{
+		if (!(_id in this.m.MSU_BehaviorStacks) || --this.m.MSU_BehaviorStacks[_id] == 0)
+			return this.removeBehavior(_id);
+	}
+});

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -195,6 +195,13 @@
 		{
 			this.saveBaseValues();
 		}
+		else
+		{
+			if (this.m.AIBehaviorID != null && !::MSU.isNull(this.getContainer()))			
+			{				
+				this.getContainer().getActor().getAIAgent().removeBehaviorByStack(this.m.AIBehaviorID);
+			}
+		}
 
 		setContainer(_c);
 


### PR DESCRIPTION
This is dependent on the changes from #244 and basically allows us to safely remove the behavior added by a skill if that skill is removed. It is far simpler than the skills thing because we don't have to care about any references or items or anything.