### PR TITLE
feat: use behavior ID only

### DIFF
--- a/msu/hooks/load.nut
+++ b/msu/hooks/load.nut
@@ -5,3 +5,4 @@
 ::includeFiles(this.IO.enumerateFiles("msu/hooks/states"));
 ::includeFiles(this.IO.enumerateFiles("msu/hooks/ui"));
 ::includeFiles(this.IO.enumerateFiles("msu/hooks/retinue"));
+::include("msu/hooks/root_state.nut");

--- a/msu/hooks/root_state.nut
+++ b/msu/hooks/root_state.nut
@@ -6,7 +6,14 @@
 
 		foreach (script in ::IO.enumerateFiles("scripts/ai/tactical/behaviors"))
 		{
-			::MSU.AI.BehaviorIDToScriptMap[::new(script).getID()] <- script;
+			try
+			{
+				::MSU.AI.BehaviorIDToScriptMap[::new(script).getID()] <- script;
+			}
+			catch (error)
+			{
+				::logError("Could not instantiate or get ID of behavior: " + script);
+			}
 		}
 
 		return ret;

--- a/msu/hooks/root_state.nut
+++ b/msu/hooks/root_state.nut
@@ -2,8 +2,6 @@
 	local onInit = o.onInit;
 	o.onInit = function()
 	{
-		local ret = onInit();
-
 		foreach (script in ::IO.enumerateFiles("scripts/ai/tactical/behaviors"))
 		{
 			try
@@ -16,6 +14,6 @@
 			}
 		}
 
-		return ret;
+		return onInit();
 	}
 });

--- a/msu/hooks/root_state.nut
+++ b/msu/hooks/root_state.nut
@@ -1,0 +1,14 @@
+::mods_hookExactClass("root_state", function(o) {
+	local onInit = o.onInit;
+	o.onInit = function()
+	{
+		local ret = onInit();
+
+		foreach (script in ::IO.enumerateFiles("scripts/ai/tactical/behaviors"))
+		{
+			::MSU.AI.BehaviorIDToScriptMap[::new(script).getID()] <- script;
+		}
+
+		return ret;
+	}
+});

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -55,7 +55,7 @@
 ::mods_hookBaseClass("skills/skill", function(o) {
 	o = o[o.SuperName];
 
-	o.m.AIBehavior <- null;
+	o.m.AIBehaviorID <- null;
 	o.m.DamageType <- ::MSU.Class.WeightedContainer();
 	o.m.ItemActionOrder <- ::Const.ItemActionOrder.Any;
 
@@ -198,9 +198,9 @@
 
 		setContainer(_c);
 
-		if (this.m.AIBehavior != null && _c != null && !this.getContainer().getActor().isPlayerControlled() && this.getContainer().getActor().getAIAgent().findBehavior(this.m.AIBehavior.ID) == null)
+		if (this.m.AIBehaviorID != null && _c != null && !this.getContainer().getActor().isPlayerControlled() && this.getContainer().getActor().getAIAgent().findBehavior(this.m.AIBehaviorID) == null)
 		{
-			this.getContainer().getActor().getAIAgent().addBehavior(::new(this.m.AIBehavior.Script));
+			this.getContainer().getActor().getAIAgent().addBehavior(::new(::MSU.AI.getBehaviorScriptFromID(this.m.AIBehaviorID)));
 			this.getContainer().getActor().getAIAgent().finalizeBehaviors();
 		}
 	}

--- a/scripts/config/msu/ai.nut
+++ b/scripts/config/msu/ai.nut
@@ -1,4 +1,21 @@
 ::MSU.AI <- {
+	BehaviorIDToScriptMap = {}, // Is populated during root_state.onInit function
+
+	function getBehaviorScriptFromID( _id )
+	{
+		if (this.m.BehaviorIDToScriptMap.len() == 0)
+		{
+			throw "This function cannot be used before the root_state.onInit function has run");
+		}
+		if (!(_id in this.m.BehaviorIDToScriptMap))
+		{
+			::logError("Invalid behavior id '" + _id + "' and/or the associated script file is not located in \'scripts/ai/tactical/behaviors\'");
+			throw ::MSU.Exception.KeyNotFound(_id);
+		}
+
+		return this.m.BehaviorIDToScriptMap[_id];
+	}
+
 	function addBehavior ( _id, _name, _order, _score )
 	{
 		if (_id in ::Const.AI.Behavior.ID) throw ::MSU.Exception.DuplicateKey(_id);

--- a/scripts/config/msu/ai.nut
+++ b/scripts/config/msu/ai.nut
@@ -5,7 +5,7 @@
 	{
 		if (this.m.BehaviorIDToScriptMap.len() == 0)
 		{
-			throw "This function cannot be used before the root_state.onInit function has run");
+			throw "This function cannot be used before the root_state.onInit function has run";
 		}
 		if (!(_id in this.m.BehaviorIDToScriptMap))
 		{

--- a/scripts/config/msu/ai.nut
+++ b/scripts/config/msu/ai.nut
@@ -9,7 +9,7 @@
 		}
 		if (!(_id in this.m.BehaviorIDToScriptMap))
 		{
-			::logError("Invalid behavior id '" + _id + "' and/or the associated script file is not located in \'scripts/ai/tactical/behaviors\'");
+			::logError("Invalid behavior id \'" + _id + "\' and/or the associated script file is not located in \'scripts/ai/tactical/behaviors\'");
 			throw ::MSU.Exception.KeyNotFound(_id);
 		}
 


### PR DESCRIPTION
This is accomplished via a hook on root_state onInit function that populates an ID to Script file name map. This way we don't need the user to pass both the id and the script file name for the behavior.