### PR TITLE
refactor: use MSU_ prefix instead of MSU table for variables

### DIFF
--- a/msu/hooks/ai/tactical/behaviors/ai_switchto_melee.nut
+++ b/msu/hooks/ai/tactical/behaviors/ai_switchto_melee.nut
@@ -8,9 +8,9 @@
 			itemsBefore[i] = clone _entity.getItems().m.Items[i];
 		}
 
-		_entity.getItems().m.MSU.IsIgnoringItemAction = true;
+		_entity.getItems().m.MSU_IsIgnoringItemAction = true;
 		local ret = onExecute(_entity);
-		_entity.getItems().m.MSU.IsIgnoringItemAction = false;
+		_entity.getItems().m.MSU_IsIgnoringItemAction = false;
 
 		if (ret)
 		{

--- a/msu/hooks/ai/tactical/behaviors/ai_switchto_ranged.nut
+++ b/msu/hooks/ai/tactical/behaviors/ai_switchto_ranged.nut
@@ -8,9 +8,9 @@
 			itemsBefore[i] = clone _entity.getItems().m.Items[i];
 		}
 
-		_entity.getItems().m.MSU.IsIgnoringItemAction = true;
+		_entity.getItems().m.MSU_IsIgnoringItemAction = true;
 		local ret = onExecute(_entity);
-		_entity.getItems().m.MSU.IsIgnoringItemAction = false;
+		_entity.getItems().m.MSU_IsIgnoringItemAction = false;
 
 		if (ret)
 		{

--- a/msu/hooks/ai/tactical/behaviors/ai_throw_bomb.nut
+++ b/msu/hooks/ai/tactical/behaviors/ai_throw_bomb.nut
@@ -8,9 +8,9 @@
 			itemsBefore[i] = clone _entity.getItems().m.Items[i];
 		}
 
-		_entity.getItems().m.MSU.IsIgnoringItemAction = true;
+		_entity.getItems().m.MSU_IsIgnoringItemAction = true;
 		local ret = onExecute(_entity);
-		_entity.getItems().m.MSU.IsIgnoringItemAction = false;
+		_entity.getItems().m.MSU_IsIgnoringItemAction = false;
 
 		if (ret && this.m.Skill == null)
 		{

--- a/msu/hooks/items/item_container.nut
+++ b/msu/hooks/items/item_container.nut
@@ -1,12 +1,10 @@
 ::mods_hookNewObject("items/item_container", function(o) {
 	o.m.ActionSkill <- null;
-	o.m.MSU <- {
-		IsIgnoringItemAction = false
-	}
+	o.m.MSU_IsIgnoringItemAction = false;
 
 	o.isActionAffordable = function ( _items )
 	{
-		if (this.m.MSU.IsIgnoringItemAction) return true;
+		if (this.m.MSU_IsIgnoringItemAction) return true;
 
 		local actionCost = this.getActionCost(_items);
 		return this.m.Actor.getActionPoints() >= actionCost;
@@ -14,7 +12,7 @@
 
 	o.getActionCost = function( _items )
 	{
-		if (this.m.MSU.IsIgnoringItemAction) return 0;
+		if (this.m.MSU_IsIgnoringItemAction) return 0;
 
 		this.m.ActionSkill = null;
 
@@ -38,7 +36,7 @@
 
 	o.payForAction = function ( _items )
 	{
-		if (this.m.MSU.IsIgnoringItemAction || _items.len() == 0) return;
+		if (this.m.MSU_IsIgnoringItemAction || _items.len() == 0) return;
 
 		local actionCost = this.getActionCost(_items);
 		this.m.Actor.setActionPoints(::Math.max(0, this.m.Actor.getActionPoints() - actionCost));


### PR DESCRIPTION
Because the MSU table within m isn't automatically set as the delegate of such tables within child classes and therefore child classes will not retain access to parent class MSU variables if the child class declares its own MSU table inside its m table.