### PR TITLE
fix: only logError about locked when _force is false

### DIFF
--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -84,7 +84,7 @@
 
 	function set( _newValue, _updateJS = true, _updatePersistence = true, _updateBeforeChangeCallback = true, _force = false, _updateAfterChangeCallback = true)
 	{
-		if (this.Locked)
+		if (this.Locked && !_force)
 		{
 			::logError("Setting \'" + this.Name + "\'' is locked and its value cannot be changed. Lock reason: " + this.getLockReason());
 			return false;


### PR DESCRIPTION
This stops the error from being printed when loading settings with locked values during loading a saved game.