### PR TITLE
feat: add ::MSU.new function

### DIFF
--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -127,3 +127,25 @@
 		_object = _object.get();
 	return typeof _object == "table" && "_release_hook_DO_NOT_delete_it_" in _object;
 }
+
+::MSU.new <- function( _script, _fields, _function = null )
+{
+	if (_fields == null && _function == null)
+	{
+		::logError("Both \'_fields\' and \'_function\' cannot be null simultaneously");
+		throw ::MSU.Exception.InvalidValue(_fields);
+	}
+
+	local obj = ::new(_script);
+	if (_fields != null)
+	{
+		foreach (key, value in _fields)
+		{
+			obj.m[key] = value;
+		}
+	}
+
+	if (_function != null) _function(obj);
+
+	return obj;
+}

--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -128,24 +128,12 @@
 	return typeof _object == "table" && "_release_hook_DO_NOT_delete_it_" in _object;
 }
 
-::MSU.new <- function( _script, _fields, _function = null )
+::MSU.new <- function( _script, _function = null )
 {
-	if (_fields == null && _function == null)
-	{
-		::logError("Both \'_fields\' and \'_function\' cannot be null simultaneously");
-		throw ::MSU.Exception.InvalidValue(_fields);
-	}
+	if (_function == null)
+		return ::new(_script);
 
-	local obj = ::new(_script);
-	if (_fields != null)
-	{
-		foreach (key, value in _fields)
-		{
-			obj.m[key] = value;
-		}
-	}
-
-	if (_function != null) _function(obj);
-
-	return obj;
+	local ret = ::new(_script);
+	_function(ret);
+	return ret;
 }


### PR DESCRIPTION
This allows creating objects with modified fields in-line. Use cases:
- Modifying values
- Initializing values

**Modifying values**
```squirrel
// vanilla style:
function onEquip()
{
	this.weapon.onEquip();
	local cleave = this.new("scripts/skills/actives/cleave");
	cleave.m.Icon = "skills/active_182.png";
	cleave.m.IconDisabled = "skills/active_182_sw.png";
	cleave.m.Overlay = "active_182";
	cleave.m.FatigueCost = 15;
	this.addSkill(cleave);
	this.addSkill(this.new("scripts/skills/actives/decapitate"));
	local skillToAdd = this.new("scripts/skills/actives/split_shield");
	skillToAdd.setFatigueCost(skillToAdd.getFatigueCostRaw() + 5);
	this.addSkill(skillToAdd);
}

// new style:
function onEquip()
{
	this.weapon.onEquip();
	this.addSkill(::MSU.new("scripts/skills/actives/cleave", {
		Icon = "skills/active_182.png";
		IconDisabled = "skills/active_182_sw.png";
		Overlay = "active_182";
		FatigueCost = 15
	}));

	this.addSkill(::new("scripts/skills/actives/decapitate"));
	this.addSkill(::MSU.new("scripts/skills/actives/split_shield"), null, @(o) o.setFatigueCost(o.getFatigueCostRaw() + 5));
}
```
This is an extreme example. While hooking weapons for Reforged, I very frequently ran into the situation where I wanted to change one or two values of a skill. In that case this is very convenient:

```squirrel
// old method
function onEquip()
{
	this.weapon.onEquip();
	local cleave = this.new("scripts/skills/actives/cleave");
	cleave.m.FatigueCost = 15;
	this.addSkill(cleave);

	local decapitate = this.new("scripts/skills/actives/decapitate");
	decapitate.m.FatigueCost = 27;
	this.addSkill(decapitate);

	local skillToAdd = this.new("scripts/skills/actives/split_shield");
	skillToAdd.setFatigueCost(skillToAdd.getFatigueCostRaw() + 5);
	this.addSkill(skillToAdd);
}

// vs new method:
function onEquip()
{
	this.weapon.onEquip();
	this.addSkill(::MSU.new("scripts/skills/actives/cleave", {FatigueCost = 15}));
	this.addSkill(::MSU.new("scripts/skills/actives/decapitate", {FatigueCost = 27}));
	this.addSkill(::MSU.new("scripts/skills/actives/split_shield"), null, @(o) o.setFatigueCost(o.getFatigueCostRaw() + 5));
}
```

**Initializing values**
As `create()` does not take arguments, I've often worked around it by creating an `init` function in my classes to set initialization values. This new method provides an alternative way to achieve that, reducing the need for an extra function:
```squirrel
// my current method:
local perkTree = ::new(::DPF.Class.PerkTree).init(value1, value2, value3);

// new method:
local perkTree = ::MSU.new(::DPF.Class.PerkTree, {key1 = value1, key2 = value2, key3 = value3});
```

**Thoughts on `_fields` parameter**
EDIT: On second thought, it is probably ok to remove this parameter and only keep `_script` and `_function`.

~~In theory the `_fields` parameter is unnecessary as `_function` can accomplish changing fields too. But since setting fields is the most common thing to change during modifying and/or initializing an object, it is much more convenient to just pass a table instead of writing a function every time. For example:~~
```squirrel
// Compare
::MSU.new("scripts/skills/actives/cleave", function(o) {
	o.m.FatigueCost = 15;
	o.m.ActionPointCost = 2;
	o.m.Icon = "xyz"
});

// vs

::MSU.new("scripts/skills/actives/cleave", {FatigueCost = 15, ActionPointCost = 2, Icon = "xyz"});
```
~~Therefore, I think it makes sense to keep both parameters.~~