### PR TITLE
feat: add onSkillsUpdated event

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -219,6 +219,10 @@
 		setFatigueCost(_f);
 	}
 
+	o.onSkillsUpdated <- function()
+	{
+	}
+
 	o.onMovementStarted <- function( _tile, _numTiles )
 	{
 	}

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -25,6 +25,8 @@
 		}
 
 		this.m.ScheduledChangesSkills.clear();
+
+		if (!this.getActor().isDying()) this.onSkillsUpdated();
 	}
 
 	o.callSkillsFunction <- function( _function, _argsArray = null, _update = true, _aliveOnly = false )
@@ -79,6 +81,26 @@
 		}
 		this.m.IsUpdating = wasUpdating;
 		return _argsArray[_argsArray.len() - 1];
+	}
+
+	o.onSkillsUpdated <- function()
+	{
+		this.callSkillsFunctionWhenAlive("onSkillsUpdated", null, false);
+
+		local shouldUpdate = this.m.SkillsToAdd.len() > 0;
+		if (!shouldUpdate)
+		{
+			foreach (skill in this.m.Skills)
+			{
+				if (skill.isGarbage())
+				{
+					shouldUpdate = true;
+					break;
+				}
+			}
+		}
+
+		if (shouldUpdate) this.update();
 	}
 
 	o.onMovementStarted <- function( _tile, _numTiles )


### PR DESCRIPTION
This implementation is superior to #208 as it accomplishes the event without the requirement of a flag variable in `m`. It also fixes an issue with the other implementation by ensuring that the update keeps looping until all skills have been added / removed. Without this fix there was a possibility that skills added/removed in onSkillsUpdated events based on changes in the previous call to the event would not be properly added/removed.