### PR TITLE
feat: add _asTarget parameter to onQueryTileTooltip

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -272,7 +272,7 @@
 	{
 	}
 
-	o.onQueryTileTooltip <- function( _tile, _tooltip )
+	o.onQueryTileTooltip <- function( _tile, _tooltip, _asTarget )
 	{
 	}
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -167,12 +167,16 @@
 		], false);
 	}
 
-	o.onQueryTileTooltip <- function( _tile, _tooltip )
+	o.onQueryTileTooltip <- function( _tile, _tooltip, _asTarget )
 	{
 		this.callSkillsFunction("onQueryTileTooltip", [
 			_tile,
-			_tooltip
+			_tooltip,
+			_asTarget
 		], false);
+
+		if (!_asTarget && _tile.IsOccupiedByActor && _tile.getEntity().getID() != this.getContainer().getActor().getID())
+			_tile.getEntity().getSkills().onQueryTileTooltip(_tile, _tooltip, true);
 	}
 
 	o.onQueryTooltip <- function( _skill, _tooltip )

--- a/msu/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/msu/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -5,7 +5,7 @@
 		local ret = tactical_queryTileTooltipData();
 		if (ret != null && ::Tactical.TurnSequenceBar.getActiveEntity() != null && ::Tactical.TurnSequenceBar.getActiveEntity().isPlayerControlled())
 		{
-			::Tactical.TurnSequenceBar.getActiveEntity().getSkills().onQueryTileTooltip(::Tactical.State.getLastTileHovered(), ret);
+			::Tactical.TurnSequenceBar.getActiveEntity().getSkills().onQueryTileTooltip(::Tactical.State.getLastTileHovered(), ret, false);
 		}
 		return ret;
 	}


### PR DESCRIPTION
This allows the skills of the entity on the target tile to also affect the tooltip. What are your thoughts about the `_tile.getEntity().getID() != this.getContainer().getActor().getID()` condition? I kept it in for consistency with `onGetHitFactors` and `onGetHitFactorsAsTarget` where the latter is only called if the target actor is different from the user. (Perhaps we should revise that too and call it even if the user is targeting himself)?