### PR TITLE
Segregate deserialize functions scope

### DIFF
--- a/msu/systems/serialization/serialization_system.nut
+++ b/msu/systems/serialization/serialization_system.nut
@@ -46,7 +46,7 @@
 		}
 		else
 		{
-			return ::MSU.Utils.deserialize(inEmulator, _object);
+			return _object == null ? ::MSU.Utils.deserialize(inEmulator) : ::MSU.Utils.deserializeInto(_object, inEmulator);
 		}
 	}
 

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -106,22 +106,13 @@
 		}
 	}
 
-	function deserialize( _in, _object = null )
+	function deserialize( _in )
 	{
 		local type = _in.readU8();
 		local isTable = type == this.DataType.Table;
 		local size = _in.readU32();
 
-		local ret;
-		if (_object == null)
-		{
-			ret = isTable ? {} : array(size);
-		}
-		else
-		{
-			ret = _object;
-			if (!isTable && ret.len() < size) ret.resize(size);
-		}
+		local ret = isTable ? {} : array(size);
 
 		for (local i = 0; i < size; i++)
 		{

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -157,6 +157,22 @@
 		return ret;
 	}
 
+	function deserializeInto( _object, _in )
+	{
+		::MSU.requireOneFromTypes(["table", "array"], _object);
+
+		local deserializedObj = ::MSU.Utils.deserialize(_in);
+
+		if (typeof _object == "table") return ::MSU.Table.merge(_object, deserializedObj);
+
+		_object.resize(::Math.max(_object.len(), deserializedObj.len()));
+		foreach (i, value in deserializedObj)
+		{
+			_object[i] = value;
+		}
+		return _object;
+	}
+
 	function operatorCompare( _compareResult, _operator )
 	{
 		switch (_compareResult)


### PR DESCRIPTION
This `Utils.deserialize` function should not change the values of any object - as this violates the single responsibility principle. It should take a metadata object and deserialize an object from it and return the deserialized object.