### PR TITLE
feat: add functions to get neighboring tiles

### DIFF
--- a/msu/utils/tile.nut
+++ b/msu/utils/tile.nut
@@ -15,7 +15,9 @@
 
 	function getNeighbors( _tile, _function = null )
 	{
-		// _function( tile ) and returns boolean
+		// _function( tile ) returns boolean
+		// iterates over all neighboring tiles and calls _function on each tile
+		// returns an array of tiles for which _function returned true
 
 		local ret = [];
 		for (local i = 0; i < 6; i++)
@@ -32,7 +34,9 @@
 
 	function getNeighbor( _tile, _function = null )
 	{
-		// _function( tile ) and returns boolean
+		// _function( tile ) returns boolean
+		// iterates over all neighboring tiles and calls _function on each tile
+		// returns the first tile for which _function returned true
 
 		for (local i = 0; i < 6; i++)
 		{

--- a/msu/utils/tile.nut
+++ b/msu/utils/tile.nut
@@ -12,4 +12,29 @@
 		
 		return true;
 	}
+
+	function getNeighbors( _tile )
+	{
+		local ret = [];
+		for (local i = 0; i < 6; i++)
+		{
+			if (_tile.hasNextTile(i))
+				ret.push(_tile.getNextTile(i));
+		}
+		return ret;
+	}
+
+	function getNeighbor( _tile, _function )
+	{
+		// _function( tile ) and returns boolean
+
+		for (local i = 0; i < 6; i++)
+		{
+			if (_tile.hasNextTile(i))
+			{
+				local nextTile = _tile.getNextTile(i);
+				if (_function(nextTile)) return nextTile;
+			}
+		}
+	}
 }

--- a/msu/utils/tile.nut
+++ b/msu/utils/tile.nut
@@ -13,18 +13,24 @@
 		return true;
 	}
 
-	function getNeighbors( _tile )
+	function getNeighbors( _tile, _function = null )
 	{
+		// _function( tile ) and returns boolean
+
 		local ret = [];
 		for (local i = 0; i < 6; i++)
 		{
 			if (_tile.hasNextTile(i))
-				ret.push(_tile.getNextTile(i));
+			{
+				local nextTile = _tile.getNextTile();
+				if (_function == null || _function(nextTile))
+					ret.push(nextTile);
+			}
 		}
 		return ret;
 	}
 
-	function getNeighbor( _tile, _function )
+	function getNeighbor( _tile, _function = null )
 	{
 		// _function( tile ) and returns boolean
 
@@ -33,8 +39,14 @@
 			if (_tile.hasNextTile(i))
 			{
 				local nextTile = _tile.getNextTile(i);
-				if (_function(nextTile)) return nextTile;
+				if (_function == null || _function(nextTile))
+					return nextTile;
 			}
 		}
+	}
+
+	function getRandomNeighbor( _tile, _function = null )
+	{
+		return ::MSU.Array.rand(this.getNeighbors(_tile, _function));
 	}
 }


### PR DESCRIPTION
The utility of the `getNeighbors` function is obvious. The utility of the `getNeighbor` function is shown below:
```squirrel
// Objective:
// Get the first empty tile adjacent to myTile

// current workflow
local targetTile;
for (local i = 0; i < 6; i++)
{
	if (myTile.hasNextTile(i))
	{
		local nextTile = myTile.getNextTile(i);
		if (nextTile.IsEmpty)
		{
			targetTile = nextTile;
			break;
		}
	}
}

// new workflow:
local targetTile = ::MSU.Tile.getNeighbor(myTile, @(tile) tile.IsEmpty);
```