### PR TITLE
feat: add isDisarmed function

### DIFF
--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -118,6 +118,11 @@
 		return s != null && !s.isHidden();
 	}
 
+	o.isDisarmed <- function()
+	{
+		return this.getSkills().hasSkill("effects.disarmed");
+	}
+
 	o.addExcludedInjuries <- function(_injuries)
 	{
 		foreach (injury in _injuries)


### PR DESCRIPTION
In vanilla there is no good way to check if a character is disarmed except by checking for `effects.disarmed` effect. However, if a mod adds another way to apply the disarmed status to a character, then other mods won't be able to check for that. This function allows a centralized isDisarmed function that mods can hook to add their checks into it.