### PR TITLE
feat: re implement onMovementStep to be able to affect actor movement

### DIFF
--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -17,14 +17,7 @@
 
 	q.onMovementStep = @(__original) function( _tile, _levelDifference )
 	{
-		local ret = __original(_tile, _levelDifference);
-
-		if (ret)
-		{
-			this.m.Skills.onMovementStep(_tile, _levelDifference);
-		}
-
-		return ret;
+		return onMovementStep(_tile, _levelDifference) && this.m.Skills.onMovementStep(_tile, _levelDifference);
 	}
 
 	// VANILLAFIX: http://battlebrothersgame.com/forums/topic/oncombatstarted-is-not-called-for-ai-characters/

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -219,6 +219,7 @@
 
 	q.onMovementStep <- function( _tile, _levelDifference )
 	{
+		return true;
 	}
 
 	q.onAfterDamageReceived <- function()

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -96,10 +96,44 @@
 
 	q.onMovementStep <- function( _tile, _levelDifference )
 	{
-		this.callSkillsFunction("onMovementStep", [
-			_tile,
-			_levelDifference
-		], false);
+		local wasUpdating = this.m.IsUpdating;
+		this.m.IsUpdating = true;
+		this.m.IsBusy = false;
+		this.m.BusyStack = 0;
+
+		local canMove = true;
+		local isRefunding = false;
+
+		foreach (skill in this.m.Skills)
+		{
+			if (!skill.isGarbage())
+			{
+				switch (_skill.onMovementStep(_tile, _levelDifference))
+				{
+					case true:
+						continue;
+
+					case false:
+						canMove = false;
+						break;
+
+					case null:
+						canMove = false;
+						isRefunding = true;
+						break;
+
+					default:
+						::logError("onMovementStep must return true, false, or null");
+						throw "invalid return value";
+				}
+			}
+		}
+
+		this.m.IsUpdating = wasUpdating;
+
+		if (isRefunding) this.m.Actor.onMovementUndo(_tile, _levelDifference);
+
+		return canMove;
 	}
 
 	q.onAnySkillExecuted <- function( _skill, _targetTile, _targetEntity, _forFree )


### PR DESCRIPTION
This makes the function actually useful. It allows skills to stop an actor's movement at a particular tile based on conditions defined in the skill's `onMovementStep` function. Note that `onMovementStep` is called for all "to-be-moved-on" tiles even before the movement starts. As long as all skills' `onMovementStep` returns true, the movement is valid. If even a single skill returns false, the movement is stopped at that tile. If any skill returns null, then the movement is stopped and the movement cost refunded.