### PR TITLE
fix: flagSerialization edge case errors

### DIFF
--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -186,16 +186,21 @@
 		if (_table.Locked) this.lock(_table.LockReason);
 	}
 
+	function getSerDeFlag()
+	{
+		return "MS." + this.getID();
+	}
+
 	function flagSerialize( _out )
 	{
-		this.getMod().Serialization.flagSerialize(format("MS.%s", this.getID()), this.__getSerializationTable());
+		this.getMod().Serialization.flagSerialize(this.getSerDeFlag(), this.__getSerializationTable());
 	}
 
 	function flagDeserialize( _in )
 	{
 		if (::MSU.Mod.Serialization.isSavedVersionAtLeast("1.2.0-rc.1", _in.getMetaData()))
 		{
-			this.__setFromSerializationTable(this.getMod().Serialization.flagDeserialize(format("MS.%s", this.getID())));
+			this.__setFromSerializationTable(this.getMod().Serialization.flagDeserialize(this.getSerDeFlag(), this.__getSerializationTable()));
 		}
 		else if (::MSU.Mod.Serialization.isSavedVersionAtLeast("0.0.1", _in.getMetaData()))
 		{

--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -188,7 +188,7 @@
 
 	function getSerDeFlag()
 	{
-		return "MS." + this.getID();
+		return "ModSetting." + this.getID();
 	}
 
 	function flagSerialize( _out )

--- a/msu/systems/serialization/deserialization_emulator.nut
+++ b/msu/systems/serialization/deserialization_emulator.nut
@@ -68,17 +68,21 @@
 		return this.__readFloat();
 	}
 
-	function loadDataFromFlagContainer( _flags ) // doesn't check if flags exist
+	function loadDataFromFlagContainer()
 	{
 		local startString = this.getEmulatorString();
-		this.Data = array(_flags.get(startString));
+		if (!this.FlagContainer.has(startString))
+			return false;
+		this.Data = array(this.FlagContainer.get(startString));
+		this.FlagContainer.remove(startString);
 		for (local i = 0; i < this.Data.len(); ++i)
 		{
-			if (_flags.has(startString + "." + i))
-			{
-				local value = _flags.get(startString + "." + i);
-				this.Data[i] = value;
-			}
+			local currentFlag = startString + "." + i;
+			if (!this.FlagContainer.has(currentFlag))
+				return false;
+			this.Data[i] = this.FlagContainer.get(currentFlag);
+			this.FlagContainer.remove(currentFlag);
 		}
+		return true;
 	}
 }

--- a/msu/systems/serialization/serde_emulator.nut
+++ b/msu/systems/serialization/serde_emulator.nut
@@ -1,17 +1,25 @@
 // Base for the Serialization and Deserialization Emulators
 ::MSU.Class.SerDeEmulator <- class
 {
+	static __IDRegex = regexp("^.*\\.\\d+$")
 	Data = null;
 	Mod = null;
 	ID = null;
 	MetaData = null;
+	FlagContainer = null;
 
-	constructor(_mod, _id, _metaDataEmulator = null)
+	constructor(_mod, _id, _flagContainer, _metaDataEmulator = null)
 	{
 		if (_metaDataEmulator == null) _metaDataEmulator = ::MSU.Class.MetaDataEmulator();
+		if (this.__IDRegex.match(_id))
+		{
+			::logError("the ID passed to flag serialization cannot end with a full stop followed by digits so it doesn't collide with internal MSU flags");
+			throw ::MSU.Exception.InvalidValue(_id);
+		}
 		this.Data = [];
 		this.Mod = _mod;
 		this.ID = _id;
+		this.FlagContainer = _flagContainer;
 		this.MetaData = _metaDataEmulator;
 	}
 
@@ -20,13 +28,13 @@
 		return format("MSU.%s.%s", this.Mod.getID(), this.ID);
 	}
 
-	function clearFlagContainer( _flags )
+	function clearFlags()
 	{
 		local startString = this.getEmulatorString();
-		_flags.remove(startString);
+		this.FlagContainer.remove(startString);
 		for (local i = 0; i < this.Data.len(); ++i)
 		{
-			_flags.remove(startString + "." + i);
+			this.FlagContainer.remove(startString + "." + i);
 		}
 	}
 

--- a/msu/systems/serialization/serialization_emulator.nut
+++ b/msu/systems/serialization/serialization_emulator.nut
@@ -1,25 +1,42 @@
 // enulates the _out object passed to onSerialize functions
 ::MSU.Class.SerializationEmulator <- class extends ::MSU.Class.SerDeEmulator
 {
+	IsIncremental = false;
+
+	function setIncremental( _bool )
+	{
+		this.IsIncremental = _bool;
+	}
+
+	function __writeData( _data )
+	{
+		this.Data.push(_data);
+		if (this.IsIncremental)
+		{
+			local startString = this.getEmulatorString();
+			this.FlagContainer.set(startString, this.Data.len());
+			this.FlagContainer.set(startString + "." + (this.Data.len() - 1), _data);
+		}
+	}
+
 	function writeString( _string )
 	{
-		this.Data.push(_string);
-		// idk about the necessity of keeping the type here as well as the value, unless someone can think of a good reason for it I will probably remove it.
+		this.__writeData(_string);
 	}
 
 	function __writeInt( _int )
 	{
-		this.Data.push(_int);
+		this.__writeData(_int);
 	}
 
 	function __writeFloat( _float )
 	{
-		this.Data.push(_float);
+		this.__writeData(_float);
 	}
 
 	function writeBool( _bool )
 	{
-		this.Data.push(_bool);
+		this.__writeData(_bool);
 	}
 
 	function writeI32( _int )
@@ -57,13 +74,18 @@
 		this.__writeFloat(_float);
 	}
 
-	function storeDataInFlagContainer( _flags )
+	function storeDataInFlagContainer()
 	{
+		if (this.IsIncremental)
+		{
+			::logError("Called storeDataInFlagContainer for an Incremental SerializationEmulator");
+			throw ::MSU.Exception.InvalidValue();
+		}
 		local startString = this.getEmulatorString();
-		_flags.set(startString, this.Data.len());
+		this.FlagContainer.set(startString, this.Data.len());
 		foreach (idx, element in this.Data)
 		{
-			_flags.set(startString + "." + idx, element);
+			this.FlagContainer.set(startString + "." + idx, element);
 		}
 	}
 }

--- a/msu/systems/serialization/serialization_mod_addon.nut
+++ b/msu/systems/serialization/serialization_mod_addon.nut
@@ -11,8 +11,18 @@
 		::MSU.System.Serialization.flagSerialize(this.Mod, _id, _object, _flags);
 	}
 
-	function flagDeserialize( _id, _object = null, _flags = null )
+	function flagDeserialize( _id, _defaultValue, _object = null, _flags = null )
 	{
-		return ::MSU.System.Serialization.flagDeserialize(this.Mod, _id, _object, _flags);
+		return ::MSU.System.Serialization.flagDeserialize(this.Mod, _id, _defaultValue, _object, _flags);
+	}
+
+	function getDeserializationEmulator( _id, _flags = null )
+	{
+		return ::MSU.System.Serialization.getDeserializationEmulator(this.Mod, _id, _flags);
+	}
+
+	function getSerializationEmulator( _id, _flags = null )
+	{
+		return ::MSU.System.Serialization.getSerializationEmulator(this.Mod, _id, _flags);
 	}
 }


### PR DESCRIPTION
serialization of BB objects is now handled by passing a Serialization or Deserialization Emulator to them.

Normal deserialiation now requires a default value.

SerDeEmulators are now permanently linked to a FlagContainer they are assigned during instantiation.

SerializationEmulators now have an Incremental mode where they store their data in the flag container as soon as something is written to them.

DeserializationEmulators now immediately clear flags from their FlagContainer as they deserialize.

SerDeEmulator flag IDs are validated to make sure they do not collide with flags generated by other emulators.