### PR TITLE
feat: set the AIBehaviorID of skills to vanilla behavior during create

### DIFF
--- a/msu/hooks/root_state.nut
+++ b/msu/hooks/root_state.nut
@@ -6,7 +6,16 @@
 		{
 			try
 			{
-				::MSU.AI.BehaviorIDToScriptMap[::new(script).getID()] <- script;
+				local behavior = ::new(script);
+				local id = behavior.getID();
+				::MSU.AI.BehaviorIDToScriptMap[id] <- script;
+				if ("PossibleSkills" in behavior.m)
+				{
+					foreach (skillID in behavior.m.PossibleSkills)
+					{
+						::MSU.AI.SkillIDToBehaviorIDMap[skillID] <- id;
+					}
+				}
 			}
 			catch (error)
 			{

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -1,6 +1,11 @@
 ::mods_hookDescendants("skills/skill", function(o) {
 	if ("create" in o)
 	{
+		o.setVanillaBehaviorID <- function()
+		{
+			this.m.AIBehaviorID = ::MSU.AI.SkillIDToBehaviorIDMap[this.getID()];
+		}
+
 		local create = o.create;
 		o.create = function()
 		{
@@ -48,6 +53,8 @@
 						this.m.DamageType.add(::Const.Damage.DamageType.Unknown);
 				}
 			}
+
+			this.setVanillaBehaviorID();
 		}
 	}
 });

--- a/msu/utils/ai.nut
+++ b/msu/utils/ai.nut
@@ -1,5 +1,6 @@
 ::MSU.AI <- {
 	BehaviorIDToScriptMap = {}, // Is populated during root_state.onInit function
+	SkillIDToBehaviorIDMap = {}, // Is populated during root_state.onInit function but used via a function in skill.nut create() hook
 
 	function getBehaviorScriptFromID( _id )
 	{


### PR DESCRIPTION
Is accomplished via a hookDescendants on skill.nut which looks for the `create` function and then adds a custom function which is called at the end of the hooked `create`. The function uses a table which is populated during root_state.onInit function to match the skill id to its vanilla behavior id. This is done to avoid having to instantiate any file during queue, which breaks hooks.