### PR TITLE
Individual locks for settings

### DIFF
--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -3,8 +3,7 @@
 	static Type = "Abstract";
 	Value = null;
 	BaseValue = null;
-	Locked = null;
-	LockReason = null;
+	Locks = null;
 	BeforeChangeCallbacks = null;
 	AfterChangeCallbacks = null;
 	Persistence = null; //if it should print change to log for further manipulation
@@ -14,8 +13,7 @@
 		base.constructor(_id, _name, _description)
 		this.Value = _value;
 		this.BaseValue = _value;
-		this.Locked = false;
-		this.LockReason = "";
+		this.Locks = {};
 		this.Persistence = true;
 		this.BeforeChangeCallbacks = [];
 		this.AfterChangeCallbacks = [];
@@ -84,7 +82,7 @@
 
 	function set( _newValue, _updateJS = true, _updatePersistence = true, _updateBeforeChangeCallback = true, _force = false, _updateAfterChangeCallback = true)
 	{
-		if (this.Locked)
+		if (this.isLocked())
 		{
 			::logError("Setting \'" + this.Name + "\'' is locked and its value cannot be changed. Lock reason: " + this.getLockReason());
 			return false;
@@ -130,35 +128,47 @@
 		local ret = base.getDescription();
 		if (this.isLocked())
 		{
-			ret += "\n\n[color=" + ::Const.UI.Color.NegativeValue + "]Locked[/color]\n";
-			if (this.LockReason != "")
-			{
-				ret += this.getLockReason();
-			}
+			ret += "\n\n[color=" + ::Const.UI.Color.NegativeValue + "]Locked[/color]\n" + this.getLockReason();
 		}
 		return ret;
 	}
 
 	function isLocked()
 	{
-		return this.Locked;
+		return this.Locks.len() != 0;
 	}
 
 	function getLockReason()
 	{
-		return this.LockReason == "" ? "" : this.LockReason.slice(0, -5);
+		local ret = "";
+		foreach (lockReason in this.Locks)
+		{
+			ret += lockReason + " +++ ";
+		}
+		return ret == "" ? "" : ret.slice(0, -5);
 	}
 
+	// Deprecated - use addLock instead
 	function lock( _lockReason = "" )
 	{
-		this.Locked = true;
-		if (_lockReason != "") this.LockReason += _lockReason + " +++ ";
+		// "MSU_LegacyLock" is for legacy support for the days when settings used to have
+		// a this.Locked Boolean which could be set/unset using lock() and unlock()
+		this.Locks["MSU_LegacyLock" + this.Locks.len()] <- _lockReason;
+	}
+
+	function addLock( _lockID, _lockReason )
+	{
+		this.Locks[_lockID] <- _lockReason;
+	}
+
+	function removeLock( _lockID )
+	{
+		if (_lockID in this.Locks) delete this.Locks[_lockID];
 	}
 
 	function unlock()
 	{
-		this.Locked = false;
-		this.LockReason = "";
+		this.Locks.clear();
 	}
 
 	function getUIData(_flags = [])

--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -173,9 +173,7 @@
 	function __getSerializationTable()
 	{
 		return {
-			Value = this.getValue(),
-			Locked = this.isLocked(),
-			LockReason = this.getLockReason()
+			Value = this.getValue()
 		};
 	}
 
@@ -183,7 +181,6 @@
 	{
 		this.unlock();
 		this.set(_table.Value, true, false, true, true);
-		if (_table.Locked) this.lock(_table.LockReason);
 	}
 
 	function flagSerialize( _out )
@@ -217,8 +214,6 @@
 				this.unlock();
 				this.set(::World.Flags.get(valueFlag), true, false, true, true);
 			}
-			setPropertyIfFlagExists("Locked", modID);
-			setPropertyIfFlagExists("LockReason", modID);
 		}
 		else
 		{

--- a/msu/systems/mod_settings/mod_settings_mod_addon.nut
+++ b/msu/systems/mod_settings/mod_settings_mod_addon.nut
@@ -64,10 +64,19 @@
 		return true;
 	}
 
-	function lockSetting( _setting, _lockReason )
+	function addLock( _setting, _lockID, _lockReason )
 	{
 		if (typeof _setting == "string") _setting = this.getSetting(_setting);
 
-		_setting.lock(_lockReason + format(" (%s (%s))", this.getMod().getID(), this.getMod().getName()));
+		_lockID = this.getMod().getID() + "." + _lockID;
+		_setting.addLock(_lockID, _lockReason);
+	}
+
+	function removeLock( _setting, _lockID )
+	{
+		if (typeof _setting == "string") _setting = this.getSetting(_setting);
+
+		_lockID = this.getMod().getID() + "." + _lockID;
+		_setting.removeLock(_lockID);
 	}
 }


### PR DESCRIPTION
- Allows individual locks to be placed on settings which can be removed on a per-lock basis.
- Major advantage: this allows settings, during their on-changed callbacks, to add/remove locks on other settings. 
- A setting is only considered unlocked once all the locks have been removed.
- While the `lock` function is deprecated, backwards compatible support for it is maintained via a legacy lock id.
- The Locked state is removed from a setting's serialization, because locks should be set via `requireSettingValue` and/or `addLock`. Serializing the locked state leads to unintended behavior when mods are added/removed.

Request: We need to add functionality, so that after "Saving" and/or "Applying" the settings - we run the requiredSettingValues check (just like we do on campaign load - see #278). And if any setting couldn't be changed to a value required by the on-change callbacks or now has a value that violates required setting values, we should throw a popup/notification to notify the user.