### PR TITLE
refactor: remove locked state from serialization

### DIFF
--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -173,9 +173,7 @@
 	function __getSerializationTable()
 	{
 		return {
-			Value = this.getValue(),
-			Locked = this.isLocked(),
-			LockReason = this.getLockReason()
+			Value = this.getValue()
 		};
 	}
 
@@ -183,7 +181,6 @@
 	{
 		this.unlock();
 		this.set(_table.Value, true, false, true, true);
-		if (_table.Locked) this.lock(_table.LockReason);
 	}
 
 	function flagSerialize( _out )
@@ -217,8 +214,6 @@
 				this.unlock();
 				this.set(::World.Flags.get(valueFlag), true, false, true, true);
 			}
-			setPropertyIfFlagExists("Locked", modID);
-			setPropertyIfFlagExists("LockReason", modID);
 		}
 		else
 		{


### PR DESCRIPTION
Because all locks should be set anew during mods queue or campaign load as per the requirements of the currently used mods.