### PR TITLE
fix: remove check for existing behavior

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -208,7 +208,7 @@
 
 		setContainer(_c);
 
-		if (this.m.AIBehaviorID != null && _c != null && this.getContainer().getActor().getAIAgent().getID() != ::Const.AI.Agent.ID.Player && this.getContainer().getActor().getAIAgent().findBehavior(this.m.AIBehaviorID) == null)
+		if (this.m.AIBehaviorID != null && _c != null && this.getContainer().getActor().getAIAgent().getID() != ::Const.AI.Agent.ID.Player)
 		{
 			this.getContainer().getActor().getAIAgent().addBehavior(::new(::MSU.AI.getBehaviorScriptFromID(this.m.AIBehaviorID)));
 			this.getContainer().getActor().getAIAgent().finalizeBehaviors();


### PR DESCRIPTION
This is important because we add behavior by stack. And if we check for pre-existing behavior, then we don't add the behavior but we still remove it when the skill is removed. This leads to issues when a skill removes itself upon execution e.g. Throw Spear or Throw Net which get removed due to the item being one-use only. As this happens mid-execution of an ai behavior, the behavior is removed and the game freezing as the behavior is no longer attached to an actor.