### PR TITLE
Feature color positive color negative

### DIFF
--- a/msu/utils/text.nut
+++ b/msu/utils/text.nut
@@ -13,4 +13,14 @@
 	{
 		return this.color(::Const.UI.Color.NegativeValue, _string);
 	}
+
+	function colorPositive( _string )
+	{
+		return this.color(::Const.UI.Color.PositiveValue, _string);
+	}
+
+	function colorNegative( _string )
+	{
+		return this.color(::Const.UI.Color.NegativeValue, _string);
+	}
 }

--- a/msu/utils/text.nut
+++ b/msu/utils/text.nut
@@ -1,4 +1,9 @@
 ::MSU.Text <- {
+	Color = {
+		Green = "#135213",
+		Red = "#8f1e1e"
+	},
+
 	function color( _color, _string )
 	{
 		return ::Const.UI.getColorized(_string, _color);

--- a/msu/utils/text.nut
+++ b/msu/utils/text.nut
@@ -11,12 +11,12 @@
 
 	function colorGreen( _string )
 	{
-		return this.color(::Const.UI.Color.PositiveValue, _string);
+		return this.color(this.Color.Green, _string);
 	}
 
 	function colorRed( _string )
 	{
-		return this.color(::Const.UI.Color.NegativeValue, _string);
+		return this.color(this.Color.Red, _string);
 	}
 
 	function colorPositive( _string )


### PR DESCRIPTION
Based on [this feedback](https://discord.com/channels/965324395851694140/1060326291238305853/1073422634425008270). The idea is that `PositiveValue` and `NegativeValue` colors should be moddable, so that if a mod wants to show positive values in some color other than green, it can.