### PR TITLE
feat: add Type mutator and accessor functions to skill.nut

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -65,6 +65,34 @@
 	o.m.IsApplyingPreview <- false;
 	o.PreviewField <- {};
 
+	o.isType = function( _t, _any = true, _only = false )
+	{
+		if (_any)
+		{
+			return _only ? this.m.Type - (this.m.Type & _t) == 0 : (this.m.Type & _t) != 0;
+		}
+		else
+		{
+			return _only ? (this.m.Type & _t) == this.m.Type : (this.m.Type & _t) == _t;
+		}
+	}
+
+	o.addType <- function ( _t )
+	{
+		this.m.Type = this.m.Type | _t;
+	}
+
+	o.setType <- function( _t )
+	{
+		this.m.Type = _t;
+	}
+
+	o.removeType <- function( _t )
+	{
+		if (this.isType(_t, false)) this.m.Type -= _t;
+		else throw ::MSU.Exception.KeyNotFound(_t);
+	}
+
 	o.scheduleChange <- function( _field, _change, _set = false )
 	{
 		this.m.ScheduledChanges.push({Field = _field, Change = _change, Set = _set});


### PR DESCRIPTION
These are pulled 1:1 from msu item.nut as Skill Type and Item Type function the same way.