### PR TITLE
fix: remove active behavior only after execution is complete

### DIFF
--- a/msu/hooks/ai/tactical/agent.nut
+++ b/msu/hooks/ai/tactical/agent.nut
@@ -2,6 +2,7 @@
 	o = o[o.SuperName];
 
 	o.m.MSU_BehaviorStacks <- {};
+	o.m.MSU_BehaviorToRemove <- null;
 
 	local addBehavior = o.addBehavior;
 	o.addBehavior = function( _behavior )
@@ -30,4 +31,22 @@
 		if (!(_id in this.m.MSU_BehaviorStacks) || --this.m.MSU_BehaviorStacks[_id] == 0)
 			return this.removeBehavior(_id);
 	}
+});
+
+::MSU.EndQueue.add(function() {
+	::mods_hookBaseClass("ai/tactical/agent", function(o) {
+		o = o[o.SuperName];
+
+		local execute = o.execute;
+		o.execute = function( _entity )
+		{
+			local ret = execute(_entity);
+			if (this.m.MSU_BehaviorToRemove != null)
+			{
+				this.removeBehaviorByStack(this.m.MSU_BehaviorToRemove.getID());
+				this.m.MSU_BehaviorToRemove = null;
+			}
+			return ret;
+		}
+	});
 });

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -201,8 +201,11 @@
 		else
 		{
 			if (this.m.AIBehaviorID != null && !::MSU.isNull(this.getContainer()))			
-			{				
-				this.getContainer().getActor().getAIAgent().removeBehaviorByStack(this.m.AIBehaviorID);
+			{
+				local agent = this.getContainer().getActor().getAIAgent();
+				local activeBehavior = agent.m.ActiveBehavior;
+				if (activeBehavior != null && activeBehavior.getID() == this.m.AIBehaviorID) agent.m.MSU_BehaviorToRemove = activeBehavior;
+				else agent.removeBehaviorByStack(this.m.AIBehaviorID);
 			}
 		}
 

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -194,24 +194,23 @@
 	local setContainer = o.setContainer;
 	o.setContainer = function( _c )
 	{
-		if (_c != null)
+		if (c == null)
 		{
-			this.saveBaseValues();
-		}
-		else
-		{
-			if (this.m.AIBehaviorID != null && !::MSU.isNull(this.getContainer()))			
+			if (this.m.AIBehaviorID != null && !::MSU.isNull(this.getContainer()))
 			{
 				local agent = this.getContainer().getActor().getAIAgent();
 				local activeBehavior = agent.m.ActiveBehavior;
 				if (activeBehavior != null && activeBehavior.getID() == this.m.AIBehaviorID) agent.m.MSU_BehaviorToRemove = activeBehavior;
 				else agent.removeBehaviorByStack(this.m.AIBehaviorID);
 			}
+
+			return setContainer(_c);
 		}
 
+		this.saveBaseValues();
 		setContainer(_c);
 
-		if (this.m.AIBehaviorID != null && _c != null && this.getContainer().getActor().getAIAgent().getID() != ::Const.AI.Agent.ID.Player)
+		if (this.m.AIBehaviorID != null && this.getContainer().getActor().getAIAgent().getID() != ::Const.AI.Agent.ID.Player)
 		{
 			this.getContainer().getActor().getAIAgent().addBehavior(::new(::MSU.AI.getBehaviorScriptFromID(this.m.AIBehaviorID)));
 			this.getContainer().getActor().getAIAgent().finalizeBehaviors();


### PR DESCRIPTION
This fixes issues when a skill is used which removes itself upon execution, leading to the skill removing its behavior mid-execution of the behavior, which leads to errors and combat freeze. With this commit, we check if the removed skill's behavior is the currently active behavior, and if yes, then only remove it after the execution is complete.