### PR TITLE
fix: metadata emulators being empty and potentially causing issues

### DIFF
--- a/msu/systems/serialization/load.nut
+++ b/msu/systems/serialization/load.nut
@@ -10,3 +10,19 @@ includeFile("deserialization_emulator");
 includeFile("serialization_system.nut");
 ::MSU.System.Serialization <- ::MSU.Class.SerializationSystem();
 includeFile("serialization_mod_addon.nut");
+
+::MSU.UI.addOnConnectCallback(function()
+{
+	local worldState = ::new("scripts/states/world_state");
+	local serEm = ::MSU.Class.SerializationEmulator(::MSU.ID, "WorldStateOnBeforeSerialize", ::new("scripts/tools/tag_collection"), ::MSU.Class.MetaDataEmulator());
+	::MSU.System.Serialization.MetaData = serEm.getMetaData();
+	::World.Assets <- {
+		getName = @() "msuDummy",
+		getBanner = @() "msuDummy",
+		getCombatDifficulty = @() 1,
+		getEconomicDifficulty = @() 1,
+		isIronman = @() false,
+	}
+	worldState.onBeforeSerialize(serEm);
+	delete ::World.Assets;
+});

--- a/msu/systems/serialization/metadata_emulator.nut
+++ b/msu/systems/serialization/metadata_emulator.nut
@@ -86,4 +86,10 @@
 	{
 		return "";
 	}
+
+	function _cloned( _original )
+	{
+		this.Data = clone _original.Data;
+		this.Version = _original.Version;
+	}
 }

--- a/msu/systems/serialization/serde_emulator.nut
+++ b/msu/systems/serialization/serde_emulator.nut
@@ -10,7 +10,7 @@
 
 	constructor(_mod, _id, _flagContainer, _metaDataEmulator = null)
 	{
-		if (_metaDataEmulator == null) _metaDataEmulator = ::MSU.Class.MetaDataEmulator();
+		if (_metaDataEmulator == null) _metaDataEmulator = clone ::MSU.System.Serialization.MetaData;
 		if (this.__IDRegex.match(_id))
 		{
 			::logError("the ID passed to flag serialization cannot end with a full stop followed by digits so it doesn't collide with internal MSU flags");

--- a/msu/systems/serialization/serialization_system.nut
+++ b/msu/systems/serialization/serialization_system.nut
@@ -2,6 +2,7 @@
 {
 	Mods = null;
 	EmulatorsToClear = null;
+	MetaData = null;
 
 	constructor()
 	{


### PR DESCRIPTION
this would occur if a mod tried to use a property of metadata they expected to exist.
For example if they use a Serialization.isSavedVersionAtLeast() check on the emulated metadata this would error.
This method extract the correct information from world_state, however it has obvious issues in that this is very non-standard behavior