### PR TITLE
fix: reset AdditionalAccuracy of skill before adding item's to it

### DIFF
--- a/msu/hooks/items/weapons/weapon.nut
+++ b/msu/hooks/items/weapons/weapon.nut
@@ -39,6 +39,7 @@
 		local ret = addSkill(_skill);
 		if (::MSU.isIn("AdditionalAccuracy", _skill.m, true))
 		{
+			_skill.resetField("AdditionalAccuracy");
 			_skill.m.AdditionalAccuracy += this.m.AdditionalAccuracy;
 			_skill.setBaseValue("AdditionalAccuracy", _skill.m.AdditionalAccuracy);
 		}


### PR DESCRIPTION
Because an update already happens during addSkill, the AdditionalAccuracy of vanilla skills (e.g. Quick Shot) is set to that of the item due to the vanilla onAfterUpdate function of Quick Shot which sets its AdditionalAccuracy to that of the item. Then we added the item's accuracy to it again and then saved that as the base value. This led to doubling the AdditionalAccuracy in the skill. By resetting it before adding the item's we ensure that the item's AdditionalAccuracy is added to the base value of the skill that it had before the update loop.