### PR TITLE
refactor: use ItemSlotSpaces instead of ItemSlot

### DIFF
--- a/msu/hooks/items/item_container.nut
+++ b/msu/hooks/items/item_container.nut
@@ -46,27 +46,15 @@
 
 	o.getStaminaModifier <- function( _slots = null )
 	{
-		if (_slots == null)
-		{
-			 _slots = clone ::Const.ItemSlot;
-			 delete _slots.None;
-			 delete _slots.COUNT;
-		}
-		else
-		{
-			if (typeof _slots == "integer") _slots = [_slots];
-		}
-
 		local ret = 0;
 
-		foreach (slot in _slots)
+		if (_slots == null) _slots = ::Const.ItemSlotSpaces; // We use the ItemSlotSpaces array because its indices align perfectly with the actually usable ItemSlots
+		else if (typeof _slots == "integer") _slots = [_slots];
+
+		for (local i = 0; i < _slots.len(); i++)
 		{
-			local items = this.getAllItemsAtSlot(slot);
-			foreach (item in items)
+			foreach (item in this.getAllItemsAtSlot(_slots == ::Const.ItemSlotSpaces ? i : _slots[i]))
 			{
-				// Avoid exceptions for items which don't have getStaminaModifier()
-				// This handles cases such as Quivers in ammo slot which don't have
-				// this function in vanilla but do in mods like Legends
 				if (::MSU.isIn("getStaminaModifier", item, true)) ret += item.getStaminaModifier();
 			}
 		}


### PR DESCRIPTION
This is more robust against the addition of other item slots in the future, as we no longer have to worry about which ItemSlot keys to keep and which to delete. The indices of the ItemSlotSpaces array will always align with the ItemSlots which are actually usable.

See the following report from Darxo on Discord which highlights a problem with the current implementation: https://discord.com/channels/965324395851694140/1083975573707161610/1083975573707161610