### PR TITLE
perf: use getAllInstances instead of getAllInstancesAsArray

### DIFF
--- a/msu/hooks/entity/tactical/tactical_entity_manager.nut
+++ b/msu/hooks/entity/tactical/tactical_entity_manager.nut
@@ -2,10 +2,13 @@
 	o.getActorsByFunction <- function( _function )
 	{
 		local ret = [];
-		foreach (actor in this.getAllInstancesAsArray())
+		foreach (faction in this.getAllInstances())
 		{
-			if (_function(actor)) ret.push(actor);
-		}		
+			foreach (actor in faction)
+			{
+				if (_function(actor)) ret.push(actor);
+			}
+		}
 		return ret;
 	}
 	


### PR DESCRIPTION
Because `getAllInstancesAsArray` iterates over all instances and pushes them to a new array and returns that. That leads to this function causing 2x iteration over all actors. The new method iterates only once.