### PR TITLE
feat: add persistent storage which doesn't require BBParser

### DIFF
--- a/msu/hooks/ui/global/data_helper.nut
+++ b/msu/hooks/ui/global/data_helper.nut
@@ -1,0 +1,14 @@
+::MSU.HooksMod.hook("scripts/ui/global/data_helper", function(q) {
+	q.convertCampaignStoragesToUIData = @( __original ) function()
+	{
+		local queryStorages = ::PersistenceManager.queryStorages;
+		::PersistenceManager.queryStorages = function()
+		{
+			return queryStorages().filter(@(_i, _v) !::MSU.String.startsWith(_v.getFileName(), "MSU#"));
+		}
+		local ret = __original();
+		::PersistenceManager.queryStorages = queryStorages;
+		return ret;
+	}
+});
+

--- a/msu/systems/persistent_data/persistent_data_mod_addon.nut
+++ b/msu/systems/persistent_data/persistent_data_mod_addon.nut
@@ -1,5 +1,6 @@
 ::MSU.Class.PersistentDataModAddon <- class extends ::MSU.Class.SystemModAddon
 {
+	// deprecated bbparser
 	function loadFile( _fileID )
 	{
 		::MSU.System.PersistentData.loadFileForMod(this.Mod.getID(), _fileID);
@@ -13,5 +14,29 @@
 	function writeToLog( _fileID, _payload )
 	{
 		::MSU.System.PersistentData.writeToLog(_fileID, this.Mod.getID(), _payload);
+	}
+
+	// MSU 1.3.0
+	function createFile( _fileName, _data, _serializationEmulator = null )
+	{
+		// _data is a table filled with any squirrel types except instances or bb objects
+	}
+
+	function loadFile( _fileName )
+	{
+		return {
+			SerializationEmulator = null,
+			Data = {}
+		}
+	}
+
+	function saveValue( _id, _value )
+	{
+		// _value can be any squirrel type except instance and not a bb object
+	}
+
+	function readValue( _id )
+	{
+
 	}
 }

--- a/msu/systems/persistent_data/persistent_data_mod_addon.nut
+++ b/msu/systems/persistent_data/persistent_data_mod_addon.nut
@@ -17,26 +17,34 @@
 	}
 
 	// MSU 1.3.0
-	function createFile( _fileName, _data, _serializationEmulator = null )
+	function prefixFileName( _fileName )
 	{
-		// _data is a table filled with any squirrel types except instances or bb objects
+		return format("MSU#%s#%s", this.Mod.getID(), _fileName);
 	}
 
-	function loadFile( _fileName )
+	function createFile( _fileName, _data )
 	{
-		return {
-			SerializationEmulator = null,
-			Data = {}
-		}
+		::MSU.System.PersistentData.createFile(this.prefixFileName(_fileName), ::MSU.Class.ArraySerializationData([_data], "Main"));
 	}
 
-	function saveValue( _id, _value )
+	function hasFile( _fileName )
 	{
-		// _value can be any squirrel type except instance and not a bb object
+		return ::MSU.System.PersistentData.hasFile(this.prefixFileName(_fileName));
 	}
 
-	function readValue( _id )
+	function getFiles()
 	{
+		local prefix = "MSU#" + this.Mod.getID();
+		return ::PersistenceManager.queryStorages().filter(@(_i, _v) ::MSU.String.startsWith(_v.getFileName(), prefix))
+	}
 
+	function deleteFile( _fileName )
+	{
+		::PersistenceManager.deleteStorage(this.prefixFileName(_fileName));
+	}
+
+	function readFile( _fileName )
+	{
+		return ::MSU.System.PersistentData.readFile(this.prefixFileName(_fileName)).getData()[0];
 	}
 }

--- a/msu/systems/persistent_data/persistent_data_mod_addon.nut
+++ b/msu/systems/persistent_data/persistent_data_mod_addon.nut
@@ -24,7 +24,7 @@
 
 	function createFile( _fileName, _data )
 	{
-		::MSU.System.PersistentData.createFile(this.prefixFileName(_fileName), ::MSU.Class.ArraySerializationData([_data], "Main"));
+		::MSU.System.PersistentData.createFile(this.prefixFileName(_fileName), ::MSU.Class.ArraySerializationData([_data]));
 	}
 
 	function hasFile( _fileName )

--- a/msu/systems/persistent_data/persistent_data_system.nut
+++ b/msu/systems/persistent_data/persistent_data_system.nut
@@ -3,6 +3,7 @@
 	Mods = null;
 	ModConfigPath = "mod_config/";
 	Separator = "@"
+	FileNameRegexp = regexp("^[\\w\\d\\,\\-\\+\\# ]+$")
 
 	constructor()
 	{
@@ -112,30 +113,34 @@
 	function createFile( _fileName, _dataArray )
 	{
 		::MSU.requireInstanceOf(::MSU.Class.AbstractSerializationData, _dataArray);
+		this.validateFileName(_fileName);
 		local storage = ::PersistenceManager.createStorage(_fileName);
 		storage.beginWrite();
 		_dataArray.serialize(storage);
 		storage.endWrite();
 	}
 
-	function fileExists( _fileName )
+	function validateFileName( _fileName )
+	{
+		if (!this.FileNameRegexp.match(_fileName))
+		{
+			::logError("Battle Brothers file saves can only contain the characters 'a-zA-Z0-9_,-+# '");
+			throw ::MSU.Exception.InvalidValue(_fileName);
+		}
+	}
+
+	function hasFile( _fileName )
 	{
 		local storages = ::PersistenceManager.queryStorages();
-		local found = false;
 		foreach (storage in storages)
-		{
 			if (storage.getFileName() == _fileName)
-			{
-				found = true;
-				break;
-			}
-		}
-		return found;
+				return true;
+		return false;
 	}
 
 	function readFile( _fileName )
 	{
-		if (!this.fileExists(_fileName))
+		if (!this.hasFile(_fileName))
 		{
 			::logError("tried to read file that doesn't exist");
 			throw ::MSU.Exception.InvalidValue(_fileName);

--- a/msu/systems/persistent_data/persistent_data_system.nut
+++ b/msu/systems/persistent_data/persistent_data_system.nut
@@ -108,4 +108,42 @@
 		result += this.Separator
 		::logInfo(result);
 	}
+
+	function createFile( _fileName, _dataArray )
+	{
+		::MSU.requireInstanceOf(::MSU.Class.AbstractSerializationData, _dataArray);
+		local storage = ::PersistenceManager.createStorage(_fileName);
+		storage.beginWrite();
+		_dataArray.serialize(storage);
+		storage.endWrite();
+	}
+
+	function fileExists( _fileName )
+	{
+		local storages = ::PersistenceManager.queryStorages();
+		local found = false;
+		foreach (storage in storages)
+		{
+			if (storage.getFileName() == _fileName)
+			{
+				found = true;
+				break;
+			}
+		}
+		return found;
+	}
+
+	function readFile( _fileName )
+	{
+		if (!this.fileExists(_fileName))
+		{
+			::logError("tried to read file that doesn't exist");
+			throw ::MSU.Exception.InvalidValue(_fileName);
+		}
+		local storage = ::PersistenceManager.loadStorage(_fileName);
+		storage.beginRead();
+		local data = ::MSU.Class.CustomSerializationData.__readValueFromStorage(storage);
+		storage.endRead();
+		return data;
+	}
 }

--- a/msu/systems/serialization/deserialization_emulator.nut
+++ b/msu/systems/serialization/deserialization_emulator.nut
@@ -1,5 +1,5 @@
 // enulates the _in object passed to onDeserialize functions
-::MSU.Class.DeserializationEmulator <- class extends ::MSU.Class.SerDeEmulator
+::MSU.Class.DeserializationEmulator <- class extends ::MSU.Class.FlagSerDeEmulator
 {
 	Idx = -1;
 

--- a/msu/systems/serialization/flag_serde_emulator.nut
+++ b/msu/systems/serialization/flag_serde_emulator.nut
@@ -1,0 +1,38 @@
+::MSU.Class.FlagSerDeEmulator <- class extends ::MSU.Class.SerDeEmulator
+{
+	static __IDRegex = regexp("^.*\\.\\d+$");
+	ID = null;
+	Mod = null;
+	Data = null;
+	FlagContainer = null;
+
+	constructor(_mod, _id, _flagContainer, _metaDataEmulator = null)
+	{
+		if (_metaDataEmulator == null) _metaDataEmulator = clone ::MSU.System.Serialization.MetaData;
+		if (this.__IDRegex.match(_id))
+		{
+			::logError("the ID passed to flag serialization cannot end with a full stop followed by digits so it doesn't collide with internal MSU flags");
+			throw ::MSU.Exception.InvalidValue(_id);
+		}
+		base.constructor(_metaDataEmulator)
+		this.Mod = _mod;
+		this.ID = _id;
+		this.FlagContainer = _flagContainer;
+		this.Data = [];
+	}
+
+	function getEmulatorString()
+	{
+		return format("MSU.%s.%s", this.Mod.getID(), this.ID);
+	}
+
+	function clearFlags()
+	{
+		local startString = this.getEmulatorString();
+		this.FlagContainer.remove(startString);
+		for (local i = 0; i < this.Data.len(); ++i)
+		{
+			this.FlagContainer.remove(startString + "." + i);
+		}
+	}
+}

--- a/msu/systems/serialization/load.nut
+++ b/msu/systems/serialization/load.nut
@@ -4,6 +4,7 @@ function includeFile( _file )
 }
 includeFile("metadata_emulator");
 includeFile("serde_emulator");
+includeFile("flag_serde_emulator");
 includeFile("serialization_emulator");
 includeFile("deserialization_emulator");
 

--- a/msu/systems/serialization/load.nut
+++ b/msu/systems/serialization/load.nut
@@ -7,10 +7,18 @@ includeFile("serde_emulator");
 includeFile("flag_serde_emulator");
 includeFile("serialization_emulator");
 includeFile("deserialization_emulator");
+includeFile("strict_serde_emulator");
+includeFile("strict_serialization_emulator");
+includeFile("strict_deserialization_emulator");
 
 includeFile("serialization_system.nut");
 ::MSU.System.Serialization <- ::MSU.Class.SerializationSystem();
 includeFile("serialization_mod_addon.nut");
+
+includeFile("serialization_types/abstract_serialization_data");
+includeFile("serialization_types/custom_serialization_data");
+includeFile("serialization_types/data_array_data");
+::MSU.includeFiles(::IO.enumerateFiles("msu/systems/serialization/serialization_types"));
 
 ::MSU.UI.addOnConnectCallback(function()
 {

--- a/msu/systems/serialization/metadata_emulator.nut
+++ b/msu/systems/serialization/metadata_emulator.nut
@@ -87,6 +87,18 @@
 		return "";
 	}
 
+	function serialize( _out )
+	{
+		_out.writeU8(this.Version);
+		::MSU.Utils.serialize(this.Data, _out);
+	}
+
+	function deserialize( _in )
+	{
+		this.Version = _in.readU8();
+		this.Data = ::MSU.Utils.deserialize(_in);
+	}
+
 	function _cloned( _original )
 	{
 		this.Data = clone _original.Data;

--- a/msu/systems/serialization/serde_emulator.nut
+++ b/msu/systems/serialization/serde_emulator.nut
@@ -1,41 +1,11 @@
 // Base for the Serialization and Deserialization Emulators
 ::MSU.Class.SerDeEmulator <- class
 {
-	static __IDRegex = regexp("^.*\\.\\d+$")
-	Data = null;
-	Mod = null;
-	ID = null;
 	MetaData = null;
-	FlagContainer = null;
 
-	constructor(_mod, _id, _flagContainer, _metaDataEmulator = null)
+	constructor( _metaDataEmulator )
 	{
-		if (_metaDataEmulator == null) _metaDataEmulator = clone ::MSU.System.Serialization.MetaData;
-		if (this.__IDRegex.match(_id))
-		{
-			::logError("the ID passed to flag serialization cannot end with a full stop followed by digits so it doesn't collide with internal MSU flags");
-			throw ::MSU.Exception.InvalidValue(_id);
-		}
-		this.Data = [];
-		this.Mod = _mod;
-		this.ID = _id;
-		this.FlagContainer = _flagContainer;
 		this.MetaData = _metaDataEmulator;
-	}
-
-	function getEmulatorString()
-	{
-		return format("MSU.%s.%s", this.Mod.getID(), this.ID);
-	}
-
-	function clearFlags()
-	{
-		local startString = this.getEmulatorString();
-		this.FlagContainer.remove(startString);
-		for (local i = 0; i < this.Data.len(); ++i)
-		{
-			this.FlagContainer.remove(startString + "." + i);
-		}
 	}
 
 	function getMetaData()

--- a/msu/systems/serialization/serialization_emulator.nut
+++ b/msu/systems/serialization/serialization_emulator.nut
@@ -1,5 +1,5 @@
 // enulates the _out object passed to onSerialize functions
-::MSU.Class.SerializationEmulator <- class extends ::MSU.Class.SerDeEmulator
+::MSU.Class.SerializationEmulator <- class extends ::MSU.Class.FlagSerDeEmulator
 {
 	IsIncremental = false;
 

--- a/msu/systems/serialization/serialization_types/abstract_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/abstract_serialization_data.nut
@@ -1,0 +1,27 @@
+::MSU.Class.AbstractSerializationData <- class
+{
+	static __Type = ::MSU.Utils.SerializationDataType.None;
+	__Data = null;
+	static DataType = ::MSU.Utils.SerializationDataType;
+
+	constructor( _data )
+	{
+		this.__Data = _data;
+	}
+
+	function getType()
+	{
+		return this.__Type;
+	}
+
+	function serialize( _out )
+	{
+		_out.writeU8(this.getType());
+		_out["write" + ::MSU.Utils.SerializationDataType.getKeyForValue(this.getType())](this.getData());
+	}
+
+	function getData()
+	{
+		return this.__Data;
+	}
+}

--- a/msu/systems/serialization/serialization_types/abstract_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/abstract_serialization_data.nut
@@ -17,7 +17,6 @@
 	function serialize( _out )
 	{
 		_out.writeU8(this.getType());
-		_out["write" + ::MSU.Utils.SerializationDataType.getKeyForValue(this.getType())](this.getData());
 	}
 
 	function getData()

--- a/msu/systems/serialization/serialization_types/array_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/array_serialization_data.nut
@@ -3,14 +3,14 @@
 	static __Type = ::MSU.Utils.SerializationDataType.Array;
 	__DataArray = null;
 
-	constructor( _data, _metaData )
+	constructor( _data )
 	{
 		if (_data == null)
 			_data = [];
 		::MSU.requireArray(_data);
-		base.constructor(_data, "array");
+		base.constructor(_data);
 
-		this.__DataArray = ::MSU.Class.DataArrayData("array_data_array");
+		this.__DataArray = ::MSU.Class.DataArrayData();
 		this.setLength(_data.len());
 
 		foreach (i, element in _data)
@@ -40,7 +40,6 @@
 	{
 		base.deserialize(_in);
 		_in.readU8();
-		_in.readString();
 		this.__DataArray.deserialize(_in);
 		local data = this.getData();
 		for (local i = 0; i < this.len(); ++i)

--- a/msu/systems/serialization/serialization_types/array_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/array_serialization_data.nut
@@ -10,7 +10,7 @@
 		::MSU.requireArray(_data);
 		base.constructor(_data);
 
-		this.__DataArray = ::MSU.Class.DataArrayData();
+		this.__DataArray = ::MSU.Class.RawDataArrayData();
 		this.setLength(_data.len());
 
 		foreach (i, element in _data)

--- a/msu/systems/serialization/serialization_types/array_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/array_serialization_data.nut
@@ -1,0 +1,51 @@
+::MSU.Class.ArraySerializationData <- class extends ::MSU.Class.CustomSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationDataType.Array;
+	__DataArray = null;
+
+	constructor( _data, _metaData )
+	{
+		if (_data == null)
+			_data = [];
+		::MSU.requireArray(_data);
+		base.constructor(_data, "array");
+
+		this.__DataArray = ::MSU.Class.DataArrayData("array_data_array");
+		this.setLength(_data.len());
+
+		foreach (i, element in _data)
+		{
+			this.__DataArray.setElement(i, this.__convertValueFromBaseType(element));
+		}
+	}
+
+	function setLength( _length )
+	{
+		this.getData().resize(_length);
+		this.__DataArray.setLength(_length);
+	}
+
+	function len()
+	{
+		return this.__DataArray.len();
+	}
+
+	function serialize( _out )
+	{
+		base.serialize(_out);
+		this.__DataArray.serialize(_out);
+	}
+
+	function deserialize( _in )
+	{
+		base.deserialize(_in);
+		_in.readU8();
+		_in.readString();
+		this.__DataArray.deserialize(_in);
+		local data = this.getData();
+		for (local i = 0; i < this.len(); ++i)
+		{
+			data[i] = this.__DataArray.getElement(i).getData()
+		}
+	}
+}

--- a/msu/systems/serialization/serialization_types/basic_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/basic_serialization_data.nut
@@ -1,0 +1,8 @@
+::MSU.Class.BasicSerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	function serialize( _out )
+	{
+		base.serialize(_out);
+		_out["write" + ::MSU.Utils.SerializationDataType.getKeyForValue(this.getType())](this.getData());
+	}
+}

--- a/msu/systems/serialization/serialization_types/bool_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/bool_serialization_data.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.BoolSerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.Bool;
+	static __Type = ::MSU.Utils.SerializationDataType.Bool;
 
 	constructor(_data)
 	{

--- a/msu/systems/serialization/serialization_types/bool_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/bool_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.BoolSerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.BoolSerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.Bool;
 

--- a/msu/systems/serialization/serialization_types/bool_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/bool_serialization_data.nut
@@ -1,0 +1,10 @@
+::MSU.Class.BoolSerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.Bool;
+
+	constructor(_data)
+	{
+		::MSU.requireBool(_data);
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/custom_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/custom_serialization_data.nut
@@ -19,7 +19,7 @@
 	// must be called when overriden
 	function serialize( _out )
 	{
-		_out.writeU8(this.getType());
+		base.serialize(_out);
 		::MSU.Class.U32SerializationData(this.len()).serialize(_out); // store length
 	}
 

--- a/msu/systems/serialization/serialization_types/custom_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/custom_serialization_data.nut
@@ -71,7 +71,7 @@
 				array.deserialize(_in);
 				return array;
 			default:
-				local unknownData =  ::MSU.Class.UnknownSerializationData(type, null);
+				local unknownData =  ::MSU.Class.UnknownSerializationData(type);
 				unknownData.deserialize(_in);
 				return unknownData;
 		}
@@ -125,7 +125,7 @@
 			case "table":
 				if (::MSU.isBBObject(_value))
 				{
-					::logError("MSU Serialization cannot handle BB Objects");
+					::logError("MSU Serialization cannot serialize BB Objects directly");
 					throw ::MSU.Exception.InvalidValue(_value);
 				}
 				return ::MSU.Class.TableSerializationData(_value);

--- a/msu/systems/serialization/serialization_types/custom_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/custom_serialization_data.nut
@@ -1,0 +1,45 @@
+::MSU.Class.CustomSerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	__MetaData = null;
+
+	constructor(_data, _metaData)
+	{
+		this.__MetaData = _metaData;
+		base.constructor(_data);
+	}
+
+	function getMetaData()
+	{
+		return this.__MetaData;
+	}
+
+	function setMetaData( _metaData )
+	{
+		this.__MetaData = _metaData;
+	}
+
+	function deserialize( _in )
+	{
+		local type = _in.readU8();
+		if (type != this.DataType.U32)
+			throw ::MSU.Exception.InvalidValue(type);
+		this.setLength(_in.readU32());
+	}
+
+	function serialize( _out )
+	{
+		_out.writeU8(this.getType());
+		_out.writeString(this.getMetaData());
+		::MSU.Class.U32SerializationData(this.len()).serialize(_out); // store length
+	}
+
+	function setLength( _length )
+	{
+		throw "TODO" // must be implemented for all containers inheriting from this object
+	}
+
+	function len()
+	{
+		throw "TODO" // must be implemented for all containers inheriting from this object
+	}
+}

--- a/msu/systems/serialization/serialization_types/custom_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/custom_serialization_data.nut
@@ -2,20 +2,9 @@
 {
 	__MetaData = null;
 
-	constructor(_data, _metaData)
+	constructor(_data)
 	{
-		this.__MetaData = _metaData;
 		base.constructor(_data);
-	}
-
-	function getMetaData()
-	{
-		return this.__MetaData;
-	}
-
-	function setMetaData( _metaData )
-	{
-		this.__MetaData = _metaData;
 	}
 
 	// must be called when overriden
@@ -31,7 +20,6 @@
 	function serialize( _out )
 	{
 		_out.writeU8(this.getType());
-		_out.writeString(this.getMetaData());
 		::MSU.Class.U32SerializationData(this.len()).serialize(_out); // store length
 	}
 
@@ -71,19 +59,19 @@
 			case this.DataType.F32:
 				return ::MSU.Class.F32SerializationData(_in.readF32());
 			case this.DataType.DataArray:
-				local dataArray = ::MSU.Class.DataArrayData(_in.readString());
+				local dataArray = ::MSU.Class.DataArrayData();
 				dataArray.deserialize(_in);
 				return dataArray;
 			case this.DataType.Table:
-				local table = ::MSU.Class.TableSerializationData(null, _in.readString());
+				local table = ::MSU.Class.TableSerializationData(null);
 				table.deserialize(_in);
 				return table;
 			case this.DataType.Array:
-				local array = ::MSU.Class.ArraySerializationData(null, _in.readString());
+				local array = ::MSU.Class.ArraySerializationData(null);
 				array.deserialize(_in);
 				return array;
 			default:
-				local unknownData =  ::MSU.Class.UnknownSerializationData(type, _in.readString());
+				local unknownData =  ::MSU.Class.UnknownSerializationData(type, null);
 				unknownData.deserialize(_in);
 				return unknownData;
 		}
@@ -140,9 +128,9 @@
 					::logError("MSU Serialization cannot handle BB Objects");
 					throw ::MSU.Exception.InvalidValue(_value);
 				}
-				return ::MSU.Class.TableSerializationData(_value, "table");
+				return ::MSU.Class.TableSerializationData(_value);
 			case "array":
-				return ::MSU.Class.ArraySerializationData(_value, "array");
+				return ::MSU.Class.ArraySerializationData(_value);
 			case "instance":
 				if (_value instanceof ::MSU.Class.AbstractSerializationData)
 					return _value;

--- a/msu/systems/serialization/serialization_types/custom_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/custom_serialization_data.nut
@@ -18,6 +18,7 @@
 		this.__MetaData = _metaData;
 	}
 
+	// must be called when overriden
 	function deserialize( _in )
 	{
 		local type = _in.readU8();
@@ -26,6 +27,7 @@
 		this.setLength(_in.readU32());
 	}
 
+	// must be called when overriden
 	function serialize( _out )
 	{
 		_out.writeU8(this.getType());
@@ -42,4 +44,116 @@
 	{
 		throw "TODO" // must be implemented for all containers inheriting from this object
 	}
+
+	function __readValueFromStorage( _in )
+	{
+		local type = _in.readU8();
+		switch (type)
+		{
+			case this.DataType.Null:
+				return ::MSU.Class.NullSerializationData();
+			case this.DataType.Bool:
+				return ::MSU.Class.BoolSerializationData(_in.readBool());
+			case this.DataType.String:
+				return ::MSU.Class.StringSerializationData(_in.readString());
+			case this.DataType.U8:
+				return ::MSU.Class.U8SerializationData(_in.readU8());
+			case this.DataType.U16:
+				return ::MSU.Class.U16SerializationData(_in.readU16());
+			case this.DataType.U32:
+				return ::MSU.Class.U32SerializationData(_in.readU32());
+			case this.DataType.I8:
+				return ::MSU.Class.I8SerializationData(_in.readI8());
+			case this.DataType.I16:
+				return ::MSU.Class.I16SerializationData(_in.readI16());
+			case this.DataType.I32:
+				return ::MSU.Class.I32SerializationData(_in.readI32());
+			case this.DataType.F32:
+				return ::MSU.Class.F32SerializationData(_in.readF32());
+			case this.DataType.DataArray:
+				local dataArray = ::MSU.Class.DataArrayData(_in.readString());
+				dataArray.deserialize(_in);
+				return dataArray;
+			case this.DataType.Table:
+				local table = ::MSU.Class.TableSerializationData(null, _in.readString());
+				table.deserialize(_in);
+				return table;
+			case this.DataType.Array:
+				local array = ::MSU.Class.ArraySerializationData(null, _in.readString());
+				array.deserialize(_in);
+				return array;
+			default:
+				local unknownData =  ::MSU.Class.UnknownSerializationData(type, _in.readString());
+				unknownData.deserialize(_in);
+				return unknownData;
+		}
+	}
+
+	function __convertValueFromBaseType( _value )
+	{
+		local type = typeof _value;
+		switch (type)
+		{
+			case "integer":
+				if (_value >= 0)
+				{
+					if (_value <= 255)
+					{
+						return ::MSU.Class.U8SerializationData(_value);
+					}
+					else if (_value <= 65535)
+					{
+						return ::MSU.Class.U16SerializationData(_value);
+					}
+					else
+					{
+						return ::MSU.Class.U32SerializationData(_value);
+					}
+				}
+				else
+				{
+					if (_value >= -128)
+					{
+						return ::MSU.Class.I8SerializationData(_value);
+					}
+					else if  (_value >= -32768)
+					{
+						return ::MSU.Class.I16SerializationData(_value);
+					}
+					else
+					{
+						return ::MSU.Class.I32SerializationData(_value);
+					}
+				}
+				break;
+			case "string":
+				return ::MSU.Class.StringSerializationData(_value);
+			case "float":
+				return ::MSU.Class.F32SerializationData(_value);
+			case "bool":
+				return ::MSU.Class.BoolSerializationData(_value);
+			case "null":
+				return ::MSU.Class.NullSerializationData();
+			case "table":
+				if (::MSU.isBBObject(_value))
+				{
+					::logError("MSU Serialization cannot handle BB Objects");
+					throw ::MSU.Exception.InvalidValue(_value);
+				}
+				return ::MSU.Class.TableSerializationData(_value, "table");
+			case "array":
+				return ::MSU.Class.ArraySerializationData(_value, "array");
+			case "instance":
+				if (_value instanceof ::MSU.Class.AbstractSerializationData)
+					return _value;
+				if (_value instanceof ::MSU.Class.StrictSerDeEmulator)
+					return _value.getDataArray();
+				::logError("MSU Serialization cannot handle instances other than descendants of ::MSU.Class.AbstractSerializationData");
+				throw ::MSU.Exception.InvalidValue(_value);
+			default:
+				::logError("Attempted to serialize unknown type");
+				throw ::MSU.Exception.InvalidType(_value);
+		}
+	}
 }
+

--- a/msu/systems/serialization/serialization_types/data_array_data.nut
+++ b/msu/systems/serialization/serialization_types/data_array_data.nut
@@ -1,0 +1,113 @@
+::MSU.Class.DataArrayData <- class extends ::MSU.Class.CustomSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationDataType.DataArray;
+
+	constructor( _metaData )
+	{
+		base.constructor([], _metaData);
+	}
+
+	// overridden functions
+
+	function setMetaData( _metaData )
+	{
+		if (this.isInitialized())
+		{
+			::logError("MetaData cannot be changed after the DataArray has been written to");
+			throw ::MSU.Exception.InvalidValue(this.isInitialized());
+		}
+		base.setMetaData(_metaData);
+	}
+
+	function setLength( _length )
+	{
+		this.getData().resize(_length);
+	}
+
+	function len()
+	{
+		return this.getData().len();
+	}
+
+	// new functions
+
+	function deserialize( _in )
+	{
+		base.deserialize(_in);
+		for (local i = 0; i < this.len(); ++i)
+		{
+			this.__loadValue(_idx, _in);
+		}
+	}
+
+	function serialize( _out )
+	{
+		base.serialize(_out);
+		_out.writeU8(this.DataType.DataArray);
+		_out.writeString(this.getMetaData());
+		::MSU.Class.U32SerializationData(this.getData().len()).serialize(_out); // store length
+		for (local i = 0; i < this.getData().len(); ++i)
+		{
+			this.getData()[i].serialize(_out);
+		}
+	}
+
+	function isInitialized()
+	{
+		return this.__Initialized;
+	}
+
+	function getElement( _idx )
+	{
+		return this.getData()[_idx];
+	}
+
+	function pushElement( _value )
+	{
+		this.getData().push(_value);
+	}
+
+	// private functions
+
+	function __loadValue( _idx, _in )
+	{
+		local type = _in.readU8();
+		switch (type)
+		{
+			case this.DataType.Bool:
+				this.getData()[_idx] = ::MSU.Class.BoolSerializationData(_in.readBool());
+				break;
+			case this.DataType.String:
+				this.getData()[_idx] = ::MSU.Class.StringSerializationData(_in.readString());
+				break;
+			case this.DataType.U8:
+				this.getData()[_idx] = ::MSU.Class.U8SerializationData(_in.readU8());
+				break;
+			case this.DataType.U16:
+				this.getData()[_idx] = ::MSU.Class.U16SerializationData(_in.readU16());
+				break;
+			case this.DataType.U32:
+				this.getData()[_idx] = ::MSU.Class.U32SerializationData(_in.readU32());
+				break;
+			case this.DataType.I8:
+				this.getData()[_idx] = ::MSU.Class.I8SerializationData(_in.readI8());
+				break;
+			case this.DataType.I16:
+				this.getData()[_idx] = ::MSU.Class.I16SerializationData(_in.readI16());
+				break;
+			case this.DataType.I32:
+				this.getData()[_idx] = ::MSU.Class.I32SerializationData(_in.readI32());
+				break;
+			case this.DataType.F32:
+				this.getData()[_idx] = ::MSU.Class.F32SerializationData(_in.readF32());
+				break;
+			case this.DataType.DataArray:
+				this.getData()[_idx] = ::MSU.Class.DataArrayData(_in.readString());
+				this.getData()[_idx].deserialize(_in);
+				break;
+			default:
+				this.getData()[_idx] = ::MSU.Class.UnknownSerializationData(type, _in.readString());
+				this.getData()[_idx].deserialize(_in);
+		}
+	}
+}

--- a/msu/systems/serialization/serialization_types/data_array_data.nut
+++ b/msu/systems/serialization/serialization_types/data_array_data.nut
@@ -1,50 +1,42 @@
-::MSU.Class.DataArrayData <- class extends ::MSU.Class.CustomSerializationData
+::include("msu/systems/serialization/serialization_types/raw_data_array_data");
+::MSU.Class.DataArrayData <- class extends ::MSU.Class.RawDataArrayData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.DataArray;
-	__InnerArray = null;
+	__MetaData = null;
 
 	constructor()
 	{
-		base.constructor(null);
-		this.__InnerArray = [];
+		base.constructor();
+		this.__MetaData = clone ::MSU.System.Serialization.MetaData;
 	}
 
 	// overridden functions
-
-	function getData()
-	{
-		return this; // data_arrays should not be handled the same way as every other serialization data and should instead be passed directly
-	}
-
-	function setLength( _length )
-	{
-		this.__InnerArray.resize(_length);
-	}
-
-	function len()
-	{
-		return this.__InnerArray.len();
-	}
-
-	// new functions
-
 	function deserialize( _in )
 	{
+		this.getMetaData().deserialize(_in);
 		base.deserialize(_in);
-		for (local i = 0; i < this.__InnerArray.len(); ++i)
-		{
-			this.__InnerArray[i] = this.__readValueFromStorage(_in);
-		}
 	}
 
 	function serialize( _out )
 	{
-		// TODO, also serialize metadata
-		base.serialize(_out);
+		_out.writeU8(this.getType());
+		this.getMetaData().serialize(_out);
+		::MSU.Class.U32SerializationData(this.len()).serialize(_out); // store length
 		for (local i = 0; i < this.__InnerArray.len(); ++i)
 		{
 			this.__InnerArray[i].serialize(_out);
 		}
+	}
+
+	// new functions
+	function getMetaData()
+	{
+		return this.__MetaData;
+	}
+
+	function setMetaData( _metaData )
+	{
+		this.__MetaData = _metaData;
 	}
 
 	function getElement( _idx )
@@ -52,25 +44,17 @@
 		return this.__InnerArray[_idx];
 	}
 
-	function setElement( _idx, _value )
-	{
-		this.__InnerArray[_idx] = _value;
-	}
-
-	function pushElement( _value )
-	{
-		this.__InnerArray.push(_value);
-	}
-
 	function createDeserializationEmulator( _metaData = null )
 	{
-		if (_metaData == null) _metaData = ::MSU.Class.MetaDataEmulator();
-		return ::MSU.Class.StrictDeserializationEmulator(_metaData, this);
+		if (_metaData != null)
+			this.setMetaData(_metaData);
+		return ::MSU.Class.StrictDeserializationEmulator(this);
 	}
 
 	function createSerializationEmulator( _metaData = null )
 	{
-		if (_metaData == null) _metaData = ::MSU.Class.MetaDataEmulator();
-		return ::MSU.Class.StrictSerializationEmulator(_metaData, this);
+		if (_metaData != null)
+			this.setMetaData(_metaData);
+		return ::MSU.Class.StrictSerializationEmulator(this);
 	}
 }

--- a/msu/systems/serialization/serialization_types/data_array_data.nut
+++ b/msu/systems/serialization/serialization_types/data_array_data.nut
@@ -1,10 +1,12 @@
 ::MSU.Class.DataArrayData <- class extends ::MSU.Class.CustomSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.DataArray;
+	__InnerArray = null;
 
 	constructor( _metaData )
 	{
-		base.constructor([], _metaData);
+		base.constructor(null, _metaData);
+		this.__InnerArray = [];
 	}
 
 	// overridden functions
@@ -19,14 +21,19 @@
 		base.setMetaData(_metaData);
 	}
 
+	function getData()
+	{
+		return this; // data_arrays should not be handled the same way as every other serialization data and should instead be passed directly
+	}
+
 	function setLength( _length )
 	{
-		this.getData().resize(_length);
+		this.__InnerArray.resize(_length);
 	}
 
 	function len()
 	{
-		return this.getData().len();
+		return this.__InnerArray.len();
 	}
 
 	// new functions
@@ -34,37 +41,34 @@
 	function deserialize( _in )
 	{
 		base.deserialize(_in);
-		for (local i = 0; i < this.len(); ++i)
+		for (local i = 0; i < this.__InnerArray.len(); ++i)
 		{
-			this.__loadValue(_idx, _in);
+			this.__InnerArray[i] = this.__readValueFromStorage(_in);
 		}
 	}
 
 	function serialize( _out )
 	{
 		base.serialize(_out);
-		_out.writeU8(this.DataType.DataArray);
-		_out.writeString(this.getMetaData());
-		::MSU.Class.U32SerializationData(this.getData().len()).serialize(_out); // store length
-		for (local i = 0; i < this.getData().len(); ++i)
+		for (local i = 0; i < this.__InnerArray.len(); ++i)
 		{
-			this.getData()[i].serialize(_out);
+			this.__InnerArray[i].serialize(_out);
 		}
-	}
-
-	function isInitialized()
-	{
-		return this.__Initialized;
 	}
 
 	function getElement( _idx )
 	{
-		return this.getData()[_idx];
+		return this.__InnerArray[_idx];
+	}
+
+	function setElement( _idx, _value )
+	{
+		this.__InnerArray[_idx] = _value;
 	}
 
 	function pushElement( _value )
 	{
-		this.getData().push(_value);
+		this.__InnerArray.push(_value);
 	}
 
 	function createDeserializationEmulator( _metaData = null )
@@ -77,49 +81,5 @@
 	{
 		if (_metaData == null) _metaData = ::MSU.Class.MetaDataEmulator();
 		return ::MSU.Class.StrictSerializationEmulator(_metaData, this);
-	}
-
-	// private functions
-
-	function __loadValue( _idx, _in )
-	{
-		local type = _in.readU8();
-		switch (type)
-		{
-			case this.DataType.Bool:
-				this.getData()[_idx] = ::MSU.Class.BoolSerializationData(_in.readBool());
-				break;
-			case this.DataType.String:
-				this.getData()[_idx] = ::MSU.Class.StringSerializationData(_in.readString());
-				break;
-			case this.DataType.U8:
-				this.getData()[_idx] = ::MSU.Class.U8SerializationData(_in.readU8());
-				break;
-			case this.DataType.U16:
-				this.getData()[_idx] = ::MSU.Class.U16SerializationData(_in.readU16());
-				break;
-			case this.DataType.U32:
-				this.getData()[_idx] = ::MSU.Class.U32SerializationData(_in.readU32());
-				break;
-			case this.DataType.I8:
-				this.getData()[_idx] = ::MSU.Class.I8SerializationData(_in.readI8());
-				break;
-			case this.DataType.I16:
-				this.getData()[_idx] = ::MSU.Class.I16SerializationData(_in.readI16());
-				break;
-			case this.DataType.I32:
-				this.getData()[_idx] = ::MSU.Class.I32SerializationData(_in.readI32());
-				break;
-			case this.DataType.F32:
-				this.getData()[_idx] = ::MSU.Class.F32SerializationData(_in.readF32());
-				break;
-			case this.DataType.DataArray:
-				this.getData()[_idx] = ::MSU.Class.DataArrayData(_in.readString());
-				this.getData()[_idx].deserialize(_in);
-				break;
-			default:
-				this.getData()[_idx] = ::MSU.Class.UnknownSerializationData(type, _in.readString());
-				this.getData()[_idx].deserialize(_in);
-		}
 	}
 }

--- a/msu/systems/serialization/serialization_types/data_array_data.nut
+++ b/msu/systems/serialization/serialization_types/data_array_data.nut
@@ -67,6 +67,18 @@
 		this.getData().push(_value);
 	}
 
+	function createDeserializationEmulator( _metaData = null )
+	{
+		if (_metaData == null) _metaData = ::MSU.Class.MetaDataEmulator();
+		return ::MSU.Class.StrictDeserializationEmulator(_metaData, this);
+	}
+
+	function createSerializationEmulator( _metaData = null )
+	{
+		if (_metaData == null) _metaData = ::MSU.Class.MetaDataEmulator();
+		return ::MSU.Class.StrictSerializationEmulator(_metaData, this);
+	}
+
 	// private functions
 
 	function __loadValue( _idx, _in )

--- a/msu/systems/serialization/serialization_types/data_array_data.nut
+++ b/msu/systems/serialization/serialization_types/data_array_data.nut
@@ -3,23 +3,13 @@
 	static __Type = ::MSU.Utils.SerializationDataType.DataArray;
 	__InnerArray = null;
 
-	constructor( _metaData )
+	constructor()
 	{
-		base.constructor(null, _metaData);
+		base.constructor(null);
 		this.__InnerArray = [];
 	}
 
 	// overridden functions
-
-	function setMetaData( _metaData )
-	{
-		if (this.isInitialized())
-		{
-			::logError("MetaData cannot be changed after the DataArray has been written to");
-			throw ::MSU.Exception.InvalidValue(this.isInitialized());
-		}
-		base.setMetaData(_metaData);
-	}
 
 	function getData()
 	{
@@ -49,6 +39,7 @@
 
 	function serialize( _out )
 	{
+		// TODO, also serialize metadata
 		base.serialize(_out);
 		for (local i = 0; i < this.__InnerArray.len(); ++i)
 		{

--- a/msu/systems/serialization/serialization_types/f32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/f32_serialization_data.nut
@@ -1,10 +1,10 @@
 ::MSU.Class.F32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.F32;
+	static __Type = ::MSU.Utils.SerializationDataType.F32;
 
 	constructor( _data )
 	{
-		::MSU.requireFloat(_data);
+		::MSU.requireOneFromTypes(["float", "integer"], _data);
 		base.constructor(_data);
 	}
 }

--- a/msu/systems/serialization/serialization_types/f32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/f32_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.F32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.F32SerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.F32;
 

--- a/msu/systems/serialization/serialization_types/f32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/f32_serialization_data.nut
@@ -1,0 +1,10 @@
+::MSU.Class.F32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.F32;
+
+	constructor( _data )
+	{
+		::MSU.requireFloat(_data);
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/i16_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i16_serialization_data.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.I16SerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.I16;
+	static __Type = ::MSU.Utils.SerializationDataType.I16;
 
 	constructor( _data )
 	{

--- a/msu/systems/serialization/serialization_types/i16_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i16_serialization_data.nut
@@ -1,0 +1,12 @@
+::MSU.Class.I16SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.I16;
+
+	constructor( _data )
+	{
+		::MSU.requireInt(_data);
+		if (_data < -32768 || _data > 32767)
+			throw ::MSU.Exception.InvalidValue(_data);
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/i16_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i16_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.I16SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.I16SerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.I16;
 

--- a/msu/systems/serialization/serialization_types/i32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i32_serialization_data.nut
@@ -1,0 +1,10 @@
+::MSU.Class.I32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.I32;
+
+	constructor( _data )
+	{
+		::MSU.requireInt(_data);
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/i32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i32_serialization_data.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.I32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.I32;
+	static __Type = ::MSU.Utils.SerializationDataType.I32;
 
 	constructor( _data )
 	{

--- a/msu/systems/serialization/serialization_types/i32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i32_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.I32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.I32SerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.I32;
 

--- a/msu/systems/serialization/serialization_types/i8_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i8_serialization_data.nut
@@ -1,0 +1,12 @@
+::MSU.Class.I8SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.I8;
+
+	constructor( _data )
+	{
+		::MSU.requireInt(_data);
+		if (_data < -128 || _data > 127)
+			throw ::MSU.Exception.InvalidValue(_data);
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/i8_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i8_serialization_data.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.I8SerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.I8;
+	static __Type = ::MSU.Utils.SerializationDataType.I8;
 
 	constructor( _data )
 	{

--- a/msu/systems/serialization/serialization_types/i8_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/i8_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.I8SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.I8SerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.I8;
 

--- a/msu/systems/serialization/serialization_types/null_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/null_serialization_data.nut
@@ -1,13 +1,8 @@
 ::MSU.Class.NullSerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.Null;
-	constructor( _data = null )
+	constructor()
 	{
 		base.constructor(null);
-	}
-
-	function serialize( _out )
-	{
-		_out.writeU8(this.getType());
 	}
 }

--- a/msu/systems/serialization/serialization_types/null_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/null_serialization_data.nut
@@ -1,0 +1,13 @@
+::MSU.Class.NullSerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationDataType.Null;
+	constructor( _data = null )
+	{
+		base.constructor(null);
+	}
+
+	function serialize( _out )
+	{
+		_out.writeU8(this.getType());
+	}
+}

--- a/msu/systems/serialization/serialization_types/raw_data_array_data.nut
+++ b/msu/systems/serialization/serialization_types/raw_data_array_data.nut
@@ -1,0 +1,64 @@
+::MSU.Class.RawDataArrayData <- class extends ::MSU.Class.CustomSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationDataType.RawDataArray;
+	__InnerArray = null;
+	__MetaData = null;
+
+	constructor()
+	{
+		base.constructor(null);
+		this.__InnerArray = [];
+	}
+
+	// overridden functions
+
+	function getData()
+	{
+		return this; // data_arrays should not be handled the same way as every other serialization data and should instead be passed directly
+	}
+
+	function setLength( _length )
+	{
+		this.__InnerArray.resize(_length);
+	}
+
+	function len()
+	{
+		return this.__InnerArray.len();
+	}
+
+	function deserialize( _in )
+	{
+		base.deserialize(_in);
+		for (local i = 0; i < this.__InnerArray.len(); ++i)
+		{
+			this.__InnerArray[i] = this.__readValueFromStorage(_in);
+		}
+	}
+
+	function serialize( _out )
+	{
+		base.serialize(_out);
+		for (local i = 0; i < this.__InnerArray.len(); ++i)
+		{
+			this.__InnerArray[i].serialize(_out);
+		}
+	}
+
+	// new functions
+
+	function getElement( _idx )
+	{
+		return this.__InnerArray[_idx];
+	}
+
+	function setElement( _idx, _value )
+	{
+		this.__InnerArray[_idx] = _value;
+	}
+
+	function pushElement( _value )
+	{
+		this.__InnerArray.push(_value);
+	}
+}

--- a/msu/systems/serialization/serialization_types/string_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/string_serialization_data.nut
@@ -1,0 +1,10 @@
+::MSU.Class.StringSerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.String;
+
+	constructor( _data )
+	{
+		::MSU.requireString(_data);
+		base.constructor( _data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/string_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/string_serialization_data.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.StringSerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.String;
+	static __Type = ::MSU.Utils.SerializationDataType.String;
 
 	constructor( _data )
 	{

--- a/msu/systems/serialization/serialization_types/string_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/string_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.StringSerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.StringSerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.String;
 

--- a/msu/systems/serialization/serialization_types/table_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/table_serialization_data.nut
@@ -1,0 +1,51 @@
+::MSU.Class.TableSerializationData <- class extends ::MSU.Class.CustomSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationDataType.Table;
+	__DataArray = null;
+
+	constructor( _data, _metaData )
+	{
+		if (_data == null)
+			_data = {};
+		::MSU.requireTable(_data)
+		base.constructor(_data, "table");
+
+		this.__DataArray = ::MSU.Class.DataArrayData("table_data_array");
+		this.setLength(_data.len()*2);
+		local i = 0;
+		foreach (key, value in _data)
+		{
+			this.__DataArray.setElement(i++, this.__convertValueFromBaseType(key));
+			this.__DataArray.setElement(i++, this.__convertValueFromBaseType(value));
+		}
+	}
+
+	function setLength( _length )
+	{
+		this.__DataArray.setLength(_length);
+	}
+
+	function len()
+	{
+		return this.__DataArray.len();
+	}
+
+	function serialize( _out )
+	{
+		base.serialize(_out);
+		this.__DataArray.serialize(_out);
+	}
+
+	function deserialize( _in )
+	{
+		base.deserialize(_in);
+		_in.readU8(); // TODO
+		_in.readString();
+		this.__DataArray.deserialize(_in);
+		local data = this.getData();
+		for (local i = 0; i < this.__DataArray.len(); i+=2)
+		{
+			data[this.__DataArray.getElement(i).getData()] <- this.__DataArray.getElement(i+1).getData();
+		}
+	}
+}

--- a/msu/systems/serialization/serialization_types/table_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/table_serialization_data.nut
@@ -10,7 +10,7 @@
 		::MSU.requireTable(_data)
 		base.constructor(_data);
 
-		this.__DataArray = ::MSU.Class.DataArrayData();
+		this.__DataArray = ::MSU.Class.RawDataArrayData();
 		this.setLength(_data.len()*2);
 		local i = 0;
 		foreach (key, value in _data)

--- a/msu/systems/serialization/serialization_types/table_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/table_serialization_data.nut
@@ -3,14 +3,14 @@
 	static __Type = ::MSU.Utils.SerializationDataType.Table;
 	__DataArray = null;
 
-	constructor( _data, _metaData )
+	constructor( _data )
 	{
 		if (_data == null)
 			_data = {};
 		::MSU.requireTable(_data)
-		base.constructor(_data, "table");
+		base.constructor(_data);
 
-		this.__DataArray = ::MSU.Class.DataArrayData("table_data_array");
+		this.__DataArray = ::MSU.Class.DataArrayData();
 		this.setLength(_data.len()*2);
 		local i = 0;
 		foreach (key, value in _data)
@@ -40,7 +40,6 @@
 	{
 		base.deserialize(_in);
 		_in.readU8(); // TODO
-		_in.readString();
 		this.__DataArray.deserialize(_in);
 		local data = this.getData();
 		for (local i = 0; i < this.__DataArray.len(); i+=2)

--- a/msu/systems/serialization/serialization_types/u16_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u16_serialization_data.nut
@@ -1,0 +1,12 @@
+::MSU.Class.U16SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.U16;
+
+	constructor( _data )
+	{
+		::MSU.requireInt(_data);
+		if (_data < 0 || _data > 65535)
+			throw ::MSU.Exception.InvalidValue(_data);
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/u16_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u16_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.U16SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.U16SerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.U16;
 

--- a/msu/systems/serialization/serialization_types/u16_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u16_serialization_data.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.U16SerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.U16;
+	static __Type = ::MSU.Utils.SerializationDataType.U16;
 
 	constructor( _data )
 	{

--- a/msu/systems/serialization/serialization_types/u32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u32_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.U32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.U32SerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.U32;
 

--- a/msu/systems/serialization/serialization_types/u32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u32_serialization_data.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.U32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.U32;
+	static __Type = ::MSU.Utils.SerializationDataType.U32;
 
 	constructor( _data )
 	{

--- a/msu/systems/serialization/serialization_types/u32_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u32_serialization_data.nut
@@ -1,0 +1,12 @@
+::MSU.Class.U32SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.U32;
+
+	constructor( _data )
+	{
+		::MSU.requireInt(_data);
+		if (_data < 0)
+			throw ::MSU.Exception.InvalidValue(_data);
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/u8_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u8_serialization_data.nut
@@ -1,4 +1,4 @@
-::MSU.Class.U8SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+::MSU.Class.U8SerializationData <- class extends ::MSU.Class.BasicSerializationData
 {
 	static __Type = ::MSU.Utils.SerializationDataType.U8;
 

--- a/msu/systems/serialization/serialization_types/u8_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u8_serialization_data.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.U8SerializationData <- class extends ::MSU.Class.AbstractSerializationData
 {
-	static __Type = ::MSU.Utils.SerializationData.U8;
+	static __Type = ::MSU.Utils.SerializationDataType.U8;
 
 	constructor( _data )
 	{

--- a/msu/systems/serialization/serialization_types/u8_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/u8_serialization_data.nut
@@ -1,0 +1,12 @@
+::MSU.Class.U8SerializationData <- class extends ::MSU.Class.AbstractSerializationData
+{
+	static __Type = ::MSU.Utils.SerializationData.U8;
+
+	constructor( _data )
+	{
+		::MSU.requireInt(_data);
+		if (_data < 0 || _data > 255)
+			throw ::MSU.Exception.InvalidValue(_data);
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/unknown_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/unknown_serialization_data.nut
@@ -1,0 +1,10 @@
+::MSU.Class.UnknownSerializationData <- class extends ::MSU.Class.DataArrayData
+{
+	__Type = null;
+
+	constructor( _type, _data )
+	{
+		this.__Type = _type;
+		base.constructor(_data);
+	}
+}

--- a/msu/systems/serialization/serialization_types/unknown_serialization_data.nut
+++ b/msu/systems/serialization/serialization_types/unknown_serialization_data.nut
@@ -1,10 +1,10 @@
-::MSU.Class.UnknownSerializationData <- class extends ::MSU.Class.DataArrayData
+::MSU.Class.UnknownSerializationData <- class extends ::MSU.Class.RawDataArrayData
 {
 	__Type = null;
 
-	constructor( _type, _data )
+	constructor( _type )
 	{
 		this.__Type = _type;
-		base.constructor(_data);
+		base.constructor();
 	}
 }

--- a/msu/systems/serialization/strict_deserialization_emulator.nut
+++ b/msu/systems/serialization/strict_deserialization_emulator.nut
@@ -1,0 +1,66 @@
+// emulates the _in object passed to onDeserialize functions
+::MSU.Class.StrictDeserializationEmulator <- class extends ::MSU.Class.SerDeEmulator
+{
+	Idx = -1;
+
+	function __readData(_type)
+	{
+		if (this.getDataArray().len() <= ++this.Idx)
+		{
+			::logError(format("Tried to read data beyond (%i) the length (%i) of the Deserialization Emulator", this.Idx, this.getDataArray().len()));
+			return null;
+		}
+		local serialization_pair = this.getDataArray().getElement(this.Idx);
+		if (serialization_pair.getType() != _type)
+		{
+			::logError(format("The type being read %s isn't the same as the type %s stored in the Deserialization Emulator", ::MSU.Utils.SerializationDataType.getKeyForValue(_type), ::MSU.Utils.SerializationDataType.getKeyForValue(this.Data[this.Idx].getType())));
+			// currently still continuing in case of conversion between integers
+		}
+		return serialization_pair.getData();
+	}
+
+	function readString()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.String);
+	}
+
+	function readBool()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.Bool);
+	}
+
+	function readI32()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.I32);
+	}
+
+	function readU32()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.U32);
+	}
+
+	function readI16()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.I16);
+	}
+
+	function readU16()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.U16);
+	}
+
+	function readI8()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.I8);
+	}
+
+	function readU8()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.U8);
+	}
+
+	function readF32()
+	{
+		return this.__readData(::MSU.Utils.SerializationDataType.F32);
+	}
+}

--- a/msu/systems/serialization/strict_deserialization_emulator.nut
+++ b/msu/systems/serialization/strict_deserialization_emulator.nut
@@ -1,5 +1,5 @@
 // emulates the _in object passed to onDeserialize functions
-::MSU.Class.StrictDeserializationEmulator <- class extends ::MSU.Class.SerDeEmulator
+::MSU.Class.StrictDeserializationEmulator <- class extends ::MSU.Class.StrictSerDeEmulator
 {
 	Idx = -1;
 

--- a/msu/systems/serialization/strict_serde_emulator.nut
+++ b/msu/systems/serialization/strict_serde_emulator.nut
@@ -1,0 +1,15 @@
+::MSU.Class.StrictSerDeEmulator <- class extends ::MSU.Class.SerDeEmulator
+{
+	DataArray = null;
+
+	constructor( _metaData, _dataArray )
+	{
+		base.constructor(_metaData);
+		this.DataArray = _dataArray;
+	}
+
+	function getDataArray()
+	{
+		return this.DataArray;
+	}
+}

--- a/msu/systems/serialization/strict_serde_emulator.nut
+++ b/msu/systems/serialization/strict_serde_emulator.nut
@@ -2,10 +2,10 @@
 {
 	DataArray = null;
 
-	constructor( _metaData, _dataArray )
+	constructor( _dataArray )
 	{
-		base.constructor(_metaData);
 		this.DataArray = _dataArray;
+		base.constructor(_dataArray.getMetaData());
 	}
 
 	function getDataArray()

--- a/msu/systems/serialization/strict_serialization_emulator.nut
+++ b/msu/systems/serialization/strict_serialization_emulator.nut
@@ -1,0 +1,53 @@
+// emulates the _out object passed to onSerialize functions
+::MSU.Class.StrictSerializationEmulator <- class extends ::MSU.Class.SerDeEmulator
+{
+	function __writeData(_data )
+	{
+		this.getDataArray().pushElement(_data);
+	}
+
+	function writeString( _string )
+	{
+		this.__writeData(::MSU.Class.StringSerializationData(_string));
+	}
+
+	function writeBool( _bool )
+	{
+		this.__writeData(::MSU.Class.BoolSerializationData(_bool));
+	}
+
+	function writeI32( _int )
+	{
+		this.__writeData(::MSU.Class.I32SerializationData(_int));
+	}
+
+	function writeU32( _int )
+	{
+		this.__writeData(::MSU.Class.U32SerializationData(_int));
+	}
+
+	function writeI16( _int )
+	{
+		this.__writeData(::MSU.Class.I16SerializationData(_int));
+	}
+
+	function writeU16( _int )
+	{
+		this.__writeData(::MSU.Class.U16SerializationData(_int));
+	}
+
+	function writeI8( _int )
+	{
+		this.__writeData(::MSU.Class.I8SerializationData(_int));
+	}
+
+	function writeU8( _int )
+	{
+		this.__writeData(::MSU.Class.U8SerializationData(_int));
+	}
+
+	function writeF32( _float )
+	{
+		this.__writeData(::MSU.Class.F32SerializationData(_float));
+	}
+}

--- a/msu/systems/serialization/strict_serialization_emulator.nut
+++ b/msu/systems/serialization/strict_serialization_emulator.nut
@@ -1,5 +1,5 @@
 // emulates the _out object passed to onSerialize functions
-::MSU.Class.StrictSerializationEmulator <- class extends ::MSU.Class.SerDeEmulator
+::MSU.Class.StrictSerializationEmulator <- class extends ::MSU.Class.StrictSerDeEmulator
 {
 	function __writeData(_data )
 	{

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -25,7 +25,8 @@
 		"F32",
 		"DataArray",
 		"Table",
-		"Array"
+		"Array",
+		"RawDataArray"
 	]),
 	Timers = {}
 	States = {},

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -13,6 +13,7 @@
 	SerializationDataType = ::MSU.Class.Enum([
 		"None",
 		"Unknown",
+		"Null",
 		"Bool",
 		"String",
 		"U8",
@@ -21,7 +22,10 @@
 		"I8",
 		"I16",
 		"I32",
-		"F32"
+		"F32",
+		"DataArray",
+		"Table",
+		"Array"
 	]),
 	Timers = {}
 	States = {},

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -10,6 +10,19 @@
 		Instance = 7,
 		Null = 8
 	},
+	SerializationDataType = ::MSU.Class.Enum([
+		"None",
+		"Unknown",
+		"Bool",
+		"String",
+		"U8",
+		"U16",
+		"U32",
+		"I8",
+		"I16",
+		"I32",
+		"F32"
+	]),
 	Timers = {}
 	States = {},
 

--- a/scripts/config/!msu.nut
+++ b/scripts/config/!msu.nut
@@ -49,5 +49,5 @@
 	::MSU.includeFiles(_files, _includeLoad);	
 }
 
-::MSU.includeFiles(::IO.enumerateFiles("msu/utils"));
 ::MSU.includeFiles(::IO.enumerateFiles("msu/classes"));
+::MSU.includeFiles(::IO.enumerateFiles("msu/utils"));


### PR DESCRIPTION
So this is a big one.

Basic interface is of course in the persistent_data_mod_addon, should be self-explanatory.

The backend stuff is a bit more interesting. Basically, I emulate the entire backend system serialization system so that we can have a soft error in case of issues and the game doesn't hard crash if a mod messes something up. The performance of this is frankly still pretty great and not an issue at all in my testing (though I admittedly haven't quantified how long stuff takes)

The way the data is structured is a bit strange but here's the basic concept.
Data is serialized by storing the type followed by the data, so when deserializing we can always safely decode it and identify when we have a type we don't know. When deserializing we immediately instantiate the correct serialiation data type for the type we read immediately after reading the type.

More complex data inherits from `CustomSerializationData `whereas basic data inherits from `BasicSerializationData`. `CustomSerializationData `has the main chunk of the (de)serialization logic, because each `SerializationData `is responsible for it's own (de)serialization, and since `CustomSerializationData `must be able to (de)serialize all data, it must contain the logic for that.

At the top level, when createFile is called with some data, it is used to instantiate an `ArraySerializationData` which then builds its internal array with all the passed data converted into `SerializationData` and prepared for serialization. The one exception is when (de)serializing BB Objects, those must use a `DataArrayData` to store and read their data. Imo this is best explained with a simple example:

```squirrel
local myData = {
    string = "someString",
    int = 124,
    float = "1.1241241",
    player = ::MSU.Class.DataArrayData(),
    table = {
        nestedInt = 1
    }
}

local myPlayer //create or grab player
myPlayer.onSerialize(myData.player.getSerializationEmulator()) // fill the DataArrayData with player data

mod.PersistentData.createFile("someName", myData) // the created file will be MSU#mod_id#someName
// it will exist in game saves but will not be shown in load/save screens due to the hook on UIDataHelper
// the data will first be fully converted using the StrictSerializationEmulator
// to ensure there will be no hard errors during file creation
// and then that will write it

// now to get data back we simply do
local readData = mod.PersistenData.readFile("someName")
// this should now equal to myData
// to get player back we can do
local readPlayer // create player from temp roster or smtng
readPlayer.onDeserialize(readData.player.getDeserializationEmulator())
```
The point is that except for DataArrayData, all the data can be infinitely nested safely without issues, which allows for completely arbitrary data organization.

The StrictSerDeEmulators also have some pretty cool uses for debugging stuff like the legends save corruption because they allow you to basically serialize the entire game into a single DataArrayData safely, guarantee either a useful error or a safe save to an external file which could then be read in a different instance which imo has huge implications.

Necro has also obviously been testing this in his origin maker which (along with MSU's mod settings) are the two major mods which would immediately hugely benefit from this system.