### PR TITLE
refactor: change certain functions to only when alive

### DIFF
--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -89,7 +89,7 @@
 
 	q.onMovementFinished <- function( _tile )
 	{
-		this.callSkillsFunction("onMovementFinished", [
+		this.callSkillsFunctionWhenAlive("onMovementFinished", [
 			_tile
 		]);
 	}
@@ -108,7 +108,7 @@
 		// to crashes if any skill tries to access the current tile in its onUpdate
 		// function as the tile at this point is not a valid tile.
 
-		this.callSkillsFunction("onAnySkillExecuted", [
+		this.callSkillsFunctionWhenAlive("onAnySkillExecuted", [
 			_skill,
 			_targetTile,
 			_targetEntity,
@@ -189,7 +189,7 @@
 
 	q.onOtherActorDeath <- function( _killer, _victim, _skill, _deathTile, _corpseTile, _fatalityType )
 	{
-		this.callSkillsFunction("onOtherActorDeath", [
+		this.callSkillsFunctionWhenAlive("onOtherActorDeath", [
 			_killer,
 			_victim,
 			_skill,


### PR DESCRIPTION
Some mods may kill certain entities during these functions, e.g. during onMovementFinished because of a certain skill/effect on the entity, which may then cause subsequently updated skills to crash. This change prevents such cases.

Example of a problem that is intended to be fixed by this PR: https://discord.com/channels/855921501286039582/855921501286039585/1210475458165084241