### PR TITLE
feat: add deepEquals function

### DIFF
--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -38,6 +38,43 @@
 		}
 	}
 
+	function deepEquals(_a, _b)
+	{
+		if (_a == _b)
+			return true;
+		if (typeof _a != typeof _b)
+			return false;
+		if (typeof _a != "array" && typeof _a != "table")
+		{
+			return false;
+		}
+		if (_a.len() != _b.len())
+		{
+			return false;
+		}
+		if (typeof _a == "array")
+		{
+			foreach (i, v in _a)
+			{
+				if (!this.deepEq(v, _b[i]))
+				{
+					return false;
+				}
+			}
+		}
+		else
+		{
+			foreach (k, v in _a)
+			{
+				if (!(k in _b) || !this.deepEq(k, _b[k]))
+				{
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
 	function serialize( _object, _out )
 	{
 		::MSU.requireOneFromTypes(["array", "table"], _object);

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -45,21 +45,15 @@
 		if (typeof _a != typeof _b)
 			return false;
 		if (typeof _a != "array" && typeof _a != "table")
-		{
 			return false;
-		}
 		if (_a.len() != _b.len())
-		{
 			return false;
-		}
 		if (typeof _a == "array")
 		{
 			foreach (i, v in _a)
 			{
 				if (!this.deepEq(v, _b[i]))
-				{
 					return false;
-				}
 			}
 		}
 		else
@@ -67,9 +61,7 @@
 			foreach (k, v in _a)
 			{
 				if (!(k in _b) || !this.deepEq(k, _b[k]))
-				{
 					return false;
-				}
 			}
 		}
 		return true;


### PR DESCRIPTION
Inspired by Hackflow's std lib deepEq which does the same thing. I ended up needing this for some assertions when unit testing modern hooks