### PR TITLE
feat: add functions to get actors adjacent and with specified distance

### DIFF
--- a/msu/hooks/entity/tactical/tactical_entity_manager.nut
+++ b/msu/hooks/entity/tactical/tactical_entity_manager.nut
@@ -86,10 +86,17 @@
 	
 	q.getAlliedActors <- function( _faction, _tile = null, _distance = null, _atDistance = false )
 	{
-		if (_tile != null && _tile.ID == 0)
+		if (_tile != null)
 		{
-			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
-			throw ::MSU.Exception.InvalidValue(_tile);
+			if (_tile.ID == 0)
+			{
+				::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
+				throw ::MSU.Exception.InvalidValue(_tile);
+			}
+			if (_distance == 1)
+			{
+				return this.getActorsWithinRange(_tile, 1, _atDistance ? 1 : 0).filter(@(_, _a) _a.isAlliedWith(_faction));
+			}
 		}
 
 		return this.getActorsByFunction(function(_actor) {
@@ -106,10 +113,17 @@
 	
 	q.getHostileActors <- function( _faction, _tile = null, _distance = null, _atDistance = false )
 	{
-		if (_tile != null && _tile.ID == 0)
+		if (_tile != null)
 		{
-			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
-			throw ::MSU.Exception.InvalidValue(_tile);
+			if (_tile.ID == 0)
+			{
+				::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
+				throw ::MSU.Exception.InvalidValue(_tile);
+			}
+			if (_distance == 1)
+			{
+				return this.getActorsWithinRange(_tile, 1, _atDistance ? 1 : 0).filter(@(_, _a) !_a.isAlliedWith(_faction));
+			}
 		}
 
 		return this.getActorsByFunction(function(_actor) {
@@ -130,10 +144,17 @@
 		{
 			return clone this.getInstancesOfFaction(_faction);
 		}
-		else if (_tile.ID == 0)
+		else
 		{
-			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
-			throw ::MSU.Exception.InvalidValue(_tile);
+			if (_tile.ID == 0)
+			{
+				::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
+				throw ::MSU.Exception.InvalidValue(_tile);
+			}
+			if (_distance == 1)
+			{
+				return this.getActorsWithinRange(_tile, 1, _atDistance ? 1 : 0).filter(@(_, _a) _a.getFaction() == _faction);
+			}
 		}
 				
 		local actors = this.getInstancesOfFaction(_faction);
@@ -150,10 +171,17 @@
 	
 	q.getNonFactionAlliedActors <- function( _faction, _tile = null, _distance = null, _atDistance = false )
 	{
-		if (_tile != null && _tile.ID == 0)
+		if (_tile != null)
 		{
-			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
-			throw ::MSU.Exception.InvalidValue(_tile);
+			if (_tile.ID == 0)
+			{
+				::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
+				throw ::MSU.Exception.InvalidValue(_tile);
+			}
+			if (_distance == 1)
+			{
+				return this.getActorsWithinRange(_tile, 1, _atDistance ? 1 : 0).filter(@(_, _a) _a.getFaction() != _faction && _a.isAlliedWith(_faction));
+			}
 		}
 
 		return this.getActorsByFunction(function(_actor) {

--- a/msu/hooks/entity/tactical/tactical_entity_manager.nut
+++ b/msu/hooks/entity/tactical/tactical_entity_manager.nut
@@ -32,6 +32,57 @@
 		}
 		return ret;
 	}
+
+	q.getActorsWithinRange <- function( _tile, _max = 1, _min = 1 )
+	{
+		if (_tile.ID == 0)
+		{
+			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
+			throw ::MSU.Exception.InvalidValue(_tile);
+		}
+
+		if (_max < _min)
+		{
+			::logError("_max must be equal to or greater than _min");
+			throw ::MSU.Exception.InvalidValue(_max);
+		}
+
+		if (_max == 1)
+		{
+			local ret = this.getAdjacentActors(_tile);
+			if (_min == 0 && _tile.IsOccupiedByActor)
+				ret.push(_tile.getEntity());
+			return ret;
+		}
+
+		return this.getActorsByFunction(function(_actor) {
+			if (!_actor.isPlacedOnMap())
+				return false;
+			local distance = _tile.getDistanceTo(_actor.getTile());
+			return distance <= _max && distance >= _min;
+		});
+	}
+
+	q.getAdjacentActors <- function( _tile )
+	{
+		if (_tile.ID == 0)
+		{
+			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
+			throw ::MSU.Exception.InvalidValue(_tile);
+		}
+
+		local ret = [];
+		for (local i = 0; i < 6; i++)
+		{
+			if (!_tile.hasNextTile(i))
+				continue;
+
+			local nextTile = _tile.getNextTile(i);
+			if (nextTile.IsOccupiedByActor)
+				ret.push(nextTile.getEntity());
+		}
+		return ret;
+	}
 	
 	q.getAlliedActors <- function( _faction, _tile = null, _distance = null, _atDistance = false )
 	{


### PR DESCRIPTION
Adds a more efficient way to get adjacent actors instead of having to iterate over all actors on the battlefield. Primarily targets issue #343. 

Usage for adjacent actors:
```squirrel
// To get all adjacent actors: 
::Tactical.Entities.getAdjacentActors(_tile);

// To get ALLIED adjacent actors:
::Tactical.Entities.getAdjacentActors(_tile).filter(@(_, a) a.isAlliedWith(myActor));

// To get Hostile adjacent actors
::Tactical.Entities.getAdjacentActors(_tile).filter(@(_, a) !a.isAlliedWith(myActor));

// To get Same Faction adjacent actors:
::Tactical.Entities.getAdjacentActors(_tile).filter(@(_, a) a.getFaction() == myActor.getFaction());

// To get ALLIED non-faction adjacent actors:
::Tactical.Entities.getAdjacentActors(_tile).filter(@(_, a) a.isAlliedWith(myActor) && a.getFaction() != myActor.getFaction());
```