### PR TITLE
Feat affordability preview improved

### DIFF
--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -1,4 +1,7 @@
 ::MSU.MH.hook("scripts/entity/tactical/actor", function(q) {
+	q.m.MSU_PreviewSkill <- null;
+	q.m.MSU_PreviewMovement <- null;
+
 	q.setActionPoints = @() function( _a )
 	{
 		this.m.ActionPoints = ::Math.round(_a);
@@ -120,6 +123,27 @@
 				this.m.ExcludedInjuries.push(injury);
 			}
 		}
+	}
+
+	q.isPreviewing <- function()
+	{
+		return this.getSkills().m.IsPreviewing;
+	}
+
+	q.getPreviewSkill <- function()
+	{
+		return this.m.MSU_PreviewSkill;
+	}
+
+	q.getPreviewMovement <- function()
+	{
+		return this.m.MSU_PreviewMovement;
+	}
+
+	q.clearPreview <- function()
+	{
+		this.m.MSU_PreviewSkill = null;
+		this.m.MSU_PreviewMovement = null;
 	}
 });
 

--- a/msu/hooks/entity/tactical/actor.nut
+++ b/msu/hooks/entity/tactical/actor.nut
@@ -1,4 +1,11 @@
 ::MSU.MH.hook("scripts/entity/tactical/actor", function(q) {
+	q.setActionPoints = @() function( _a )
+	{
+		this.m.ActionPoints = ::Math.round(_a);
+		if (!this.getSkills().m.IsPreviewing)
+			this.setPreviewActionPoints(_a);
+	}
+
 	q.onMovementStart = @(__original) function ( _tile, _numTiles )
 	{
 		__original(_tile, _numTiles);

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -62,8 +62,8 @@
 	q.m.IsBaseValuesSaved <- false;
 	q.m.ScheduledChanges <- []; // Deprecated
 
-	q.m.IsApplyingPreview <- false;
-	q.m.PreviewField <- {};
+	q.m.IsApplyingPreview <- false; // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
+	q.m.PreviewField <- {}; // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 
 	q.isType = @() function( _t, _any = true, _only = false )
 	{
@@ -347,15 +347,18 @@
 		this.onAfterUpdate(_properties);
 	}
 
+	// Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 	q.onAffordablePreview <- function( _skill, _movementTile )
 	{
 	}
 
+	// Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 	q.modifyPreviewField <- function( _skill, _field, _newChange, _multiplicative )
 	{
 		::MSU.Skills.modifyPreview(this, _skill, _field, _newChange, _multiplicative);
 	}
 
+	// Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 	q.modifyPreviewProperty <- function( _skill, _field, _newChange, _multiplicative )
 	{
 		::MSU.Skills.modifyPreview(this, null, _field, _newChange, _multiplicative);
@@ -498,6 +501,7 @@
 
 ::MSU.QueueBucket.VeryLate.push(function() {
 	::MSU.MH.hook("scripts/skills/skill", function(q) {
+		// Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 		foreach (func in ::MSU.Skills.PreviewApplicableFunctions)
 		{
 			q[func] = @(__original) function()
@@ -559,6 +563,7 @@
 			}
 		}
 
+		// Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 		q.isAffordablePreview = @(__original) function()
 		{
 			if (!this.getContainer().m.IsPreviewing) return __original();

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -579,7 +579,7 @@
 			local preview = ::Tactical.TurnSequenceBar.m.ActiveEntityCostsPreview;
 			if (preview != null && preview.id == this.getContainer().getActor().getID())
 			{
-				this.getContainer().updatePreview(::Tactical.TurnSequenceBar.m.MSU_PreviewSkill, ::Tactical.TurnSequenceBar.m.MSU_PreviewMovement);
+				this.getContainer().updatePreview(preview.MSU_PreviewSkill, preview.MSU_PreviewMovement);
 				this.m.IsApplyingPreview = true;
 				local ret = __original();
 				this.m.IsApplyingPreview = false;

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -337,6 +337,16 @@
 	{
 	}
 
+	q.onUpdatePreview <- function( _properties, _previewedSkill, _previewedMovement )
+	{
+		this.onUpdate(_properties);
+	}
+
+	q.onAfterUpdatePreview <- function( _properties, _previewedSkill, _previewedMovement )
+	{
+		this.onAfterUpdate(_properties);
+	}
+
 	q.onAffordablePreview <- function( _skill, _movementTile )
 	{
 	}
@@ -564,9 +574,11 @@
 			local preview = ::Tactical.TurnSequenceBar.m.ActiveEntityCostsPreview;
 			if (preview != null && preview.id == this.getContainer().getActor().getID())
 			{
+				this.getContainer().updatePreview(::Tactical.TurnSequenceBar.m.MSU_PreviewSkill, ::Tactical.TurnSequenceBar.m.MSU_PreviewMovement);
 				this.m.IsApplyingPreview = true;
 				local ret = __original();
 				this.m.IsApplyingPreview = false;
+				this.getContainer().update();
 				local skillID = this.getContainer().getActor().getPreviewSkillID();
 				local str = " after " + (skillID == "" ? "moving" : "using " + this.getContainer().getSkillByID(skillID).getName());
 				ret = ::MSU.String.replace(ret, "Fatigue[/color]", "Fatigue[/color]" + str);

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -60,7 +60,7 @@
 	q.m.ItemActionOrder <- ::Const.ItemActionOrder.Any;
 
 	q.m.IsBaseValuesSaved <- false;
-	q.m.ScheduledChanges <- [];
+	q.m.ScheduledChanges <- []; // Deprecated
 
 	q.m.IsApplyingPreview <- false;
 	q.m.PreviewField <- {};
@@ -93,12 +93,14 @@
 		else throw ::MSU.Exception.KeyNotFound(_t);
 	}
 
+	// Deprecated
 	q.scheduleChange <- function( _field, _change, _set = false )
 	{
 		this.m.ScheduledChanges.push({Field = _field, Change = _change, Set = _set});
 		this.getContainer().m.ScheduledChangesSkills.push(this);
 	}
 
+	// Deprecated
 	q.executeScheduledChanges <- function()
 	{
 		if (this.m.ScheduledChanges.len() == 0)

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -579,11 +579,13 @@
 			local preview = ::Tactical.TurnSequenceBar.m.ActiveEntityCostsPreview;
 			if (preview != null && preview.id == this.getContainer().getActor().getID())
 			{
-				this.getContainer().updatePreview(preview.MSU_PreviewSkill, preview.MSU_PreviewMovement);
+				this.getContainer().update();
 				this.m.IsApplyingPreview = true;
 				local ret = __original();
 				this.m.IsApplyingPreview = false;
+				this.getContainer().m.IsPreviewing = false;
 				this.getContainer().update();
+				this.getContainer().m.IsPreviewing = true;
 				local skillID = this.getContainer().getActor().getPreviewSkillID();
 				local str = " after " + (skillID == "" ? "moving" : "using " + this.getContainer().getSkillByID(skillID).getName());
 				ret = ::MSU.String.replace(ret, "Fatigue[/color]", "Fatigue[/color]" + str);

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -1,5 +1,5 @@
 ::MSU.MH.hook("scripts/skills/skill_container", function(q) {
-	q.m.ScheduledChangesSkills <- [];
+	q.m.ScheduledChangesSkills <- []; // Deprecated
 	q.m.IsPreviewing <- false;
 	q.m.PreviewProperty <- {};
 
@@ -17,12 +17,13 @@
 
 		__original();
 
+		// Deprecated
 		foreach (skill in this.m.ScheduledChangesSkills)
 		{
 			if (!skill.isGarbage()) skill.executeScheduledChanges();
 		}
 
-		this.m.ScheduledChangesSkills.clear();
+		this.m.ScheduledChangesSkills.clear(); // Deprecated
 	}
 
 	q.callSkillsFunction <- function( _function, _argsArray = null, _update = true, _aliveOnly = false )
@@ -286,7 +287,7 @@
 
 		getChange("onUpdate");
 		getChange("onAfterUpdate");
-		getChange("executeScheduledChanges");
+		getChange("executeScheduledChanges"); // Deprecated
 
 		foreach (changes in ::MSU.Skills.QueuedPreviewChanges)
 		{

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -309,44 +309,6 @@
 		::MSU.Skills.QueuedPreviewChanges.clear();
 	}
 
-	q.updatePreview <- function( _previewedSkill, _previewedMovement )
-	{
-		if (this.m.IsUpdating || !this.m.Actor.isAlive())
-			return;
-
-		foreach (skill in this.m.Skills)
-		{
-			if (!skill.isGarbage())
-				skill.softReset();
-		}
-
-		local properties = this.m.Actor.getBaseProperties().getClone();
-
-		this.m.IsUpdating = true;
-
-		foreach (skill in this.m.Skills)
-		{
-			if (!skill.isGarbage())
-				skill.onUpdatePreview(properties, _previewedSkill, _previewedMovement);
-		}
-
-		foreach (skill in this.m.Skills)
-		{
-			if (!skill.isGarbage())
-				skill.onAfterUpdatePreview(properties, _previewedSkill, _previewedMovement);
-		}
-
-		// Deprecated
-		foreach (skill in this.m.ScheduledChangesSkills)
-		{
-			skill.executeScheduledChanges();
-		}
-
-		this.m.IsUpdating = false;
-
-		this.m.Actor.setCurrentProperties(properties);
-	}
-
 	//Vanilla Overwrites start
 	
 	q.onAfterDamageReceived = @() function()
@@ -406,12 +368,14 @@
 	q.onTurnEnd = @() function()
 	{
 		this.m.IsPreviewing = false;
+		this.getActor().clearPreview();
 		this.callSkillsFunctionWhenAlive("onTurnEnd");
 	}
 
 	q.onWaitTurn = @() function()
 	{
 		this.m.IsPreviewing = false;
+		this.getActor().clearPreview();
 		this.callSkillsFunctionWhenAlive("onWaitTurn");
 	}
 
@@ -509,6 +473,7 @@
 	q.onCombatFinished = @() function()
 	{
 		this.m.IsPreviewing = false;
+		this.getActor().clearPreview();
 		this.callSkillsFunction("onCombatFinished");
 	}
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -296,20 +296,15 @@
 			{
 				local previewTable = change.TargetSkill == null ? this.m.PreviewProperty : change.TargetSkill.m.PreviewField;
 
-				if (!(change.Field in previewTable)) previewTable[change.Field] <- { Change = change.Multiplicative ? 1 : 0, Multiplicative = change.Multiplicative };
+				if (!(change.Field in previewTable))
+					previewTable[change.Field] <- { Change = change.Multiplicative ? 1 : 0, Multiplicative = change.Multiplicative };
 
 				if (change.Multiplicative)
-				{
 					previewTable[change.Field].Change *= change.NewChange / (change.CurrChange == 0 ? 1 : change.CurrChange);
-				}
 				else if (typeof change.NewChange == "bool")
-				{
 					previewTable[change.Field].Change = change.NewChange;
-				}
 				else
-				{
 					previewTable[change.Field].Change += change.NewChange - change.CurrChange;
-				}
 			}
 		}
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -326,6 +326,44 @@
 		::MSU.Skills.QueuedPreviewChanges.clear();
 	}
 
+	q.updatePreview <- function( _previewedSkill, _previewedMovement )
+	{
+		if (this.m.IsUpdating || !this.m.Actor.isAlive())
+			return;
+
+		foreach (skill in this.m.Skills)
+		{
+			if (!skill.isGarbage())
+				skill.softReset();
+		}
+
+		local properties = this.m.Actor.getBaseProperties().getClone();
+
+		this.m.IsUpdating = true;
+
+		foreach (skill in this.m.Skills)
+		{
+			if (!skill.isGarbage())
+				skill.onUpdatePreview(properties, _previewedSkill, _previewedMovement);
+		}
+
+		foreach (skill in this.m.Skills)
+		{
+			if (!skill.isGarbage())
+				skill.onAfterUpdatePreview(properties, _previewedSkill, _previewedMovement);
+		}
+
+		// Deprecated
+		foreach (skill in this.m.ScheduledChangesSkills)
+		{
+			skill.executeScheduledChanges();
+		}
+
+		this.m.IsUpdating = false;
+
+		this.m.Actor.setCurrentProperties(properties);
+	}
+
 	//Vanilla Overwrites start
 	
 	q.onAfterDamageReceived = @() function()

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -294,18 +294,7 @@
 		{
 			foreach (change in changes)
 			{
-				local target;
-				local previewTable;
-				if (change.TargetSkill != null)
-				{
-					target = change.TargetSkill.m;
-					previewTable = change.TargetSkill.m.PreviewField;
-				}
-				else
-				{
-					target = this.getActor().getCurrentProperties();
-					previewTable = this.m.PreviewProperty;
-				}
+				local previewTable = change.TargetSkill == null ? this.m.PreviewProperty : change.TargetSkill.m.PreviewField;
 
 				if (!(change.Field in previewTable)) previewTable[change.Field] <- { Change = change.Multiplicative ? 1 : 0, Multiplicative = change.Multiplicative };
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -225,15 +225,13 @@
 	q.onAffordablePreview <- function( _skill, _movementTile )
 	{
 		this.m.PreviewProperty.clear();
+
 		foreach (skill in this.m.Skills)
 		{
 			skill.m.PreviewField.clear();
+			if (!skill.isGarbage())
+				skill.onAffordablePreview(_skill, _movementTile);
 		}
-
-		this.callSkillsFunction("onAffordablePreview", [
-			_skill,
-			_movementTile,
-		], false);
 
 		if (::MSU.Skills.QueuedPreviewChanges.len() == 0) return;
 

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -1,7 +1,7 @@
 ::MSU.MH.hook("scripts/skills/skill_container", function(q) {
 	q.m.ScheduledChangesSkills <- []; // Deprecated
 	q.m.IsPreviewing <- false;
-	q.m.PreviewProperty <- {};
+	q.m.PreviewProperty <- {}; // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 
 	q.update = @(__original) function()
 	{
@@ -221,6 +221,7 @@
 		]);
 	}
 
+	// Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 	q.onAffordablePreview <- function( _skill, _movementTile )
 	{
 		this.m.PreviewProperty.clear();

--- a/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -52,7 +52,7 @@
 				activeEntity.getSkills().m.IsPreviewing = true;
 				this.m.MSU_PreviewSkill = skill;
 				this.m.MSU_PreviewMovement = movement;
-				activeEntity.getSkills().onAffordablePreview(skill, movement == null ? null : movement.End);
+				activeEntity.getSkills().onAffordablePreview(skill, movement == null ? null : movement.End); // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 				activeEntity.getSkills().updatePreview(skill, movement);
 			}
 		}

--- a/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -35,36 +35,35 @@
 
 	q.setActiveEntityCostsPreview = @(__original) function( _costsPreview )
 	{
-		if (::MSU.Mod.ModSettings.getSetting("ExpandedSkillTooltips").getValue())
-		{
-			local activeEntity = this.getActiveEntity();
-			if (activeEntity != null)
-			{
-				local skillID = "SkillID" in _costsPreview ? _costsPreview.SkillID : "";
-				local skill;
-				local movement;
-				if (skillID == "")
-				{
-					movement = ::Tactical.getNavigator().getCostForPath(activeEntity, ::Tactical.getNavigator().getLastSettings(), activeEntity.getActionPoints(), activeEntity.getFatigueMax() - activeEntity.getFatigue());
-				}
-				else skill = activeEntity.getSkills().getSkillByID(skillID);
+		if (!::MSU.Mod.ModSettings.getSetting("ExpandedSkillTooltips").getValue())
+			return __original(_costsPreview);
 
-				activeEntity.getSkills().m.IsPreviewing = true;
-				this.m.MSU_PreviewSkill = skill;
-				this.m.MSU_PreviewMovement = movement;
-				activeEntity.getSkills().onAffordablePreview(skill, movement == null ? null : movement.End); // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
-				activeEntity.getSkills().updatePreview(skill, movement);
-			}
-		}
+		local activeEntity = this.getActiveEntity();
+		if (activeEntity == null)
+			return __original(_costsPreview);
+
+		local skillID = "SkillID" in _costsPreview ? _costsPreview.SkillID : "";
+		local skill;
+		local movement;
+		if (skillID == "")
+			movement = ::Tactical.getNavigator().getCostForPath(activeEntity, ::Tactical.getNavigator().getLastSettings(), activeEntity.getActionPoints(), activeEntity.getFatigueMax() - activeEntity.getFatigue());
+		else
+			skill = activeEntity.getSkills().getSkillByID(skillID);
+
+		activeEntity.getSkills().m.IsPreviewing = true;
+		this.m.MSU_PreviewSkill = skill;
+		this.m.MSU_PreviewMovement = movement;
+		activeEntity.getSkills().onAffordablePreview(skill, movement == null ? null : movement.End); // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
+		activeEntity.getSkills().updatePreview(skill, movement);
 
 		this.m.MSU_JSHandle.__JSHandle = this.m.JSHandle;
 		this.m.JSHandle = this.m.MSU_JSHandle;
-		__original(_costsPreview);
+		local ret = __original(_costsPreview);
 		this.m.JSHandle = this.m.MSU_JSHandle.__JSHandle;
 		this.m.JSHandle.asyncCall("updateCostsPreview", this.m.ActiveEntityCostsPreview);
-		local activeEntity = this.getActiveEntity();
-		if (activeEntity != null)
-			activeEntity.getSkills().update();
+
+		activeEntity.getSkills().update();
+		return ret;
 	}
 
 	q.resetActiveEntityCostsPreview = @(__original) function()

--- a/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -1,7 +1,4 @@
 ::MSU.MH.hook("scripts/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar", function(q) {
-	q.m.MSU_PreviewSkill <- null;
-	q.m.MSU_PreviewMovement <- null;
-
 	q.create = @(__original) function()
 	{
 		__original();
@@ -51,8 +48,6 @@
 			skill = activeEntity.getSkills().getSkillByID(skillID);
 
 		activeEntity.getSkills().m.IsPreviewing = true;
-		this.m.MSU_PreviewSkill = skill;
-		this.m.MSU_PreviewMovement = movement;
 		activeEntity.getSkills().onAffordablePreview(skill, movement == null ? null : movement.End); // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 		activeEntity.getSkills().updatePreview(skill, movement);
 
@@ -62,6 +57,9 @@
 		this.m.JSHandle = this.m.MSU_JSHandle.__JSHandle;
 		this.m.JSHandle.asyncCall("updateCostsPreview", this.m.ActiveEntityCostsPreview);
 
+		this.m.ActiveEntityCostsPreview.MSU_PreviewSkill <- skill;
+		this.m.ActiveEntityCostsPreview.MSU_PreviewMovement <- movement;
+
 		activeEntity.getSkills().update();
 		return ret;
 	}
@@ -69,12 +67,7 @@
 	q.resetActiveEntityCostsPreview = @(__original) function()
 	{
 		local activeEntity = this.getActiveEntity();
-		if (activeEntity != null)
-		{
-			activeEntity.getSkills().m.IsPreviewing = false;
-			this.m.MSU_PreviewSkill = null;
-			this.m.MSU_PreviewMovement = null;
-		}
+		if (activeEntity != null) activeEntity.getSkills().m.IsPreviewing = false;
 		__original();
 	}
 });

--- a/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -49,7 +49,9 @@
 
 		activeEntity.getSkills().m.IsPreviewing = true;
 		activeEntity.getSkills().onAffordablePreview(skill, movement == null ? null : movement.End); // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
-		activeEntity.getSkills().updatePreview(skill, movement);
+		activeEntity.m.MSU_PreviewSkill = skill;
+		activeEntity.m.MSU_PreviewMovement = movement;
+		activeEntity.getSkills().update();
 
 		this.m.MSU_JSHandle.__JSHandle = this.m.JSHandle;
 		this.m.JSHandle = this.m.MSU_JSHandle;
@@ -57,17 +59,20 @@
 		this.m.JSHandle = this.m.MSU_JSHandle.__JSHandle;
 		this.m.JSHandle.asyncCall("updateCostsPreview", this.m.ActiveEntityCostsPreview);
 
-		this.m.ActiveEntityCostsPreview.MSU_PreviewSkill <- skill;
-		this.m.ActiveEntityCostsPreview.MSU_PreviewMovement <- movement;
-
+		activeEntity.getSkills().m.IsPreviewing = false;
 		activeEntity.getSkills().update();
+		activeEntity.getSkills().m.IsPreviewing = true;
 		return ret;
 	}
 
 	q.resetActiveEntityCostsPreview = @(__original) function()
 	{
 		local activeEntity = this.getActiveEntity();
-		if (activeEntity != null) activeEntity.getSkills().m.IsPreviewing = false;
+		if (activeEntity != null)
+		{
+			activeEntity.getSkills().m.IsPreviewing = false;
+			activeEntity.clearPreview();
+		}
 		__original();
 	}
 });

--- a/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -1,4 +1,7 @@
 ::MSU.MH.hook("scripts/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar", function(q) {
+	q.m.MSU_PreviewSkill <- null;
+	q.m.MSU_PreviewMovement <- null;
+
 	q.create = @(__original) function()
 	{
 		__original();
@@ -39,16 +42,18 @@
 			{
 				local skillID = "SkillID" in _costsPreview ? _costsPreview.SkillID : "";
 				local skill;
-				local movementTile;
+				local movement;
 				if (skillID == "")
 				{
-					local movement = ::Tactical.getNavigator().getCostForPath(activeEntity, ::Tactical.getNavigator().getLastSettings(), activeEntity.getActionPoints(), activeEntity.getFatigueMax() - activeEntity.getFatigue());
-					movementTile = movement.End;
+					movement = ::Tactical.getNavigator().getCostForPath(activeEntity, ::Tactical.getNavigator().getLastSettings(), activeEntity.getActionPoints(), activeEntity.getFatigueMax() - activeEntity.getFatigue());
 				}
 				else skill = activeEntity.getSkills().getSkillByID(skillID);
 
 				activeEntity.getSkills().m.IsPreviewing = true;
-				activeEntity.getSkills().onAffordablePreview(skill, movementTile);
+				this.m.MSU_PreviewSkill = skill;
+				this.m.MSU_PreviewMovement = movement;
+				activeEntity.getSkills().onAffordablePreview(skill, movement == null ? null : movement.End);
+				activeEntity.getSkills().updatePreview(skill, movement);
 			}
 		}
 
@@ -57,12 +62,20 @@
 		__original(_costsPreview);
 		this.m.JSHandle = this.m.MSU_JSHandle.__JSHandle;
 		this.m.JSHandle.asyncCall("updateCostsPreview", this.m.ActiveEntityCostsPreview);
+		local activeEntity = this.getActiveEntity();
+		if (activeEntity != null)
+			activeEntity.getSkills().update();
 	}
 
 	q.resetActiveEntityCostsPreview = @(__original) function()
 	{
 		local activeEntity = this.getActiveEntity();
-		if (activeEntity != null) activeEntity.getSkills().m.IsPreviewing = false;
+		if (activeEntity != null)
+		{
+			activeEntity.getSkills().m.IsPreviewing = false;
+			this.m.MSU_PreviewSkill = null;
+			this.m.MSU_PreviewMovement = null;
+		}
 		__original();
 	}
 });

--- a/msu/utils/skills.nut
+++ b/msu/utils/skills.nut
@@ -1,9 +1,9 @@
 ::MSU.Skills <- {
-	PreviewApplicableFunctions = [
+	PreviewApplicableFunctions = [ // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 		"getActionPointCost",
 		"getFatigueCost"
 	],
-	QueuedPreviewChanges = {},
+	QueuedPreviewChanges = {}, // Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 	SoftResetFields = [
 		"ActionPointCost",
 		"FatigueCost",
@@ -48,6 +48,7 @@
 		});
 	}
 
+	// Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 	function addPreviewApplicableFunction( _name )
 	{
 		::MSU.requireString(_name);
@@ -65,6 +66,7 @@
 		if (idx != null) this.SoftResetFields.remove(idx);
 	}
 
+	// Deprecated - Only needed for the legacy onAffordablePreview system -- use the new onUpdatePreview and onAfterUpdatePreview system
 	// Private
 	function modifyPreview( _caller, _targetSkill, _field, _newChange, _multiplicative )
 	{


### PR DESCRIPTION
This contains two deprecation commits. The feature of this PR is in the main `feat` commit, so you may wanna look into the diff of that commit only to get an overview of how it works.

I would like to deprecate the scheduled changes system of skills because, while it is an interesting idea, I think there are plenty of ways to work around it if you design/implement skills in a smart way. Personally I have never used it, and I believe it is a bloat to support further.

This is a massive improvement over the current Affordability Preview system we have in MSU which I implemented in #88. That system is convoluted to work with from the user's perspective and is also limited in certain aspects. The new system is far more intuitive and in fact covers some edge cases which the old system failed in.

**Old System (the one this PR deprecates):**
- Basically requires you to use `modifyPreviewField` and `modifyPreviewProperty` functions from inside a skill's `onAffordablePreview` function. The parameters of those functions are convoluted to work with.
- The system calculates the overall change by first "undoing" the change from the skill in its `onUpdate`, `onAfterUpdate`, and `executeScheduledChanges` functions and then applies the new change.
- A major limitation of this system is that the changes are applied at the end, so during the affordability preview function you don't have access to the values of other skills which would be in the regular update order by the time this skill's function comes up.

**New System:**
- We add two new functions `onUpdatePreview` and `onAfterUpdatePreview` which by default call their regular counterparts. But you can overwrite these functions for custom functionality during previewing.
- This makes the system very straightforward.
- On the back end the system achieves this by strategically placing "preview" type updates and then regular updates of the `skill_container` in between getting the affordability status of skills and their cost string. This is probably less "efficient" than the old system but honestly this is better and I wish I had done it this way the first time around.
- This also solves the major issue above and in fact gives you **FULL** control during those preview functions to do whatever you want.

**Example:**
Let's say I have a skill which after at least 2 tiles reduces the AP cost of all attacks by 1. But this effect expires when you use any skill.

**Old System usage:**
```squirrel
function onAfterUpdate( _properties )
{
	if (this.getContainer().getActor().getTile().getDistanceTo(this.m.StartingTile) >= 2)
	{
		foreach (skill in this.getContainer().getAllSkillsOfType(::Const.SkillType.Active))
		{
			if (skill.isAttack() && skill.m.ActionPointCost > 1) // Notice we only want to decrease the AP cost if it is 2 or more
				skill.m.ActionPointCost -= 1;
		}
	}
}

function onAffordablePreview( _skill, _movementTile )
{
	// The character is previewing the usage of a skill, so we want to remove the AP cost reduction
	if (_skill != null)
	{
		foreach (skill in this.getContainer().getAllSkillsOfType(::Const.SkillType.Active))
		{			
			this.modifyPreviewField(skill, "ActionPointCost", 0, false);
		}
	}
	// The character is previewing a movement, so we want to apply the AP cost reduction if applicable
	else if (_movementTile != null)
	{
		// If we have already traveled at least 2 tiles this turn, we don't want to reduce the AP cost further
		if (this.getContainer().getActor().getTile().getDistanceTo(this.m.StartingTile) >= 2)
			return;

		if (_movementTile.getDistanceTo(this.getContainer().getActor().getTile()) >= 2)
		{
			foreach (skill in this.getContainer().getAllSkillsOfType(::Const.SkillType.Active))
			{	
				// Notice there is no way for us to first check here if the skill's AP cost 		
				// is actually 2 or more at this point in the update cycle, because this onAffordablePreview function
				// doesn't work like that
			if (skill.isAttack())
				this.modifyPreviewField(skill, "ActionPointCost", -1 , false);
			}
		}
	}
}
```

**New System:**
```squirrel
function onAfterUpdate( _properties )
{
	if (this.getContainer().getActor().getTile().getDistanceTo(this.m.StartingTile) >= 2)
	{
		foreach (skill in this.getContainer().getAllSkillsOfType(::Const.SkillType.Active))
		{
			if (skill.isAttack() && skill.m.ActionPointCost > 1) // Notice we only want to decrease the AP cost if it is 2 or more
				skill.m.ActionPointCost -= 1;
		}
	}
}

function onAfterUpdatePreview( _properties, _previewedSkill, _previewedMovement )
{
	// The character is previewing the usage of a skill
	if (_previewedSkill != null)
	{
		// Do nothing i.e. apply no bonus from this perk
	}
	// The character is previewing a movement, so we want to apply the AP cost reduction if applicable
	else if (_previewedMovement != null)
	{
		// If we have already traveled at least 2 tiles this turn, we don't want to reduce the AP cost further
		if (this.getContainer().getActor().getTile().getDistanceTo(this.m.StartingTile) >= 2)
			return;

		if (_previewedMovement.End.getDistanceTo(this.getContainer().getActor().getTile()) >= 2)
		{
			foreach (skill in this.getContainer().getAllSkillsOfType(::Const.SkillType.Active))
			{	
				// Because this function runs in the same order as onAfterUpdate, we can actually check for the
				// AP cost of the skill at this point (in addition to the "preview" changes from other skills) which is fantastic!
				if (skill.isAttack() && skill.m.ActionPointCost > 1)
					skill.m.ActionPointCost -= 1;
			}
		}
	}
}
```