### PR TITLE
perf: remove check for typeof instance

### DIFF
--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -1,6 +1,6 @@
 ::MSU.isNull <- function( _object )
 {
-	return _object == null || (typeof _object == "instance" && _object instanceof ::WeakTableRef && _object.isNull());
+	return _object == null || (_object instanceof ::WeakTableRef && _object.isNull());
 }
 
 ::MSU.getField <- function( _object, _key )


### PR DESCRIPTION
Because it is redundant with the instanceof check.