### PR TITLE
perf: remove redundant typeof instance check from various functions

### DIFF
--- a/msu/systems/system.nut
+++ b/msu/systems/system.nut
@@ -31,7 +31,7 @@
 
 	function registerMod( _mod )
 	{
-		if (typeof _mod != "instance" || !(_mod instanceof ::MSU.Class.Mod))
+		if (!(_mod instanceof ::MSU.Class.Mod))
 		{
 			throw ::MSU.Exception.InvalidType(_mod);
 		}

--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -89,7 +89,7 @@
 ::MSU.isKindOf <- function( _object, _className )
 {
 	if (_object == null || _className == null) return false;
-	if (typeof _object == "instance" && _object instanceof ::WeakTableRef)
+	if (_object instanceof ::WeakTableRef)
 	{
 		if (_object.isNull()) return false;
 		_object = _object.get();
@@ -115,15 +115,15 @@
 
 ::MSU.isEqual <- function( _1, _2 )
 {
-	if (typeof _1 == "instance" && _1 instanceof ::WeakTableRef) _1 = _1.get();
-	if (typeof _2 == "instance" && _2 instanceof ::WeakTableRef) _2 = _2.get();
+	if (_1 instanceof ::WeakTableRef) _1 = _1.get();
+	if (_2 instanceof ::WeakTableRef) _2 = _2.get();
 
 	return _1 == _2;
 }
 
 ::MSU.isBBObject <- function( _object, _allowWeakTableRef = true )
 {
-	if (typeof _object == "instance" && _object instanceof ::WeakTableRef && _allowWeakTableRef)
+	if (_object instanceof ::WeakTableRef && _allowWeakTableRef)
 		_object = _object.get();
 	return typeof _object == "table" && "_release_hook_DO_NOT_delete_it_" in _object;
 }

--- a/msu/utils/type_checkers.nut
+++ b/msu/utils/type_checkers.nut
@@ -37,7 +37,7 @@
 {
 	foreach (value in vargv)
 	{
-		if (typeof value != "instance" || !(value instanceof _class))
+		if (!(value instanceof _class))
 		{
 			::logError(value + " must be an instance of the class: " + _class);
 			throw ::MSU.Exception.InvalidType(value);


### PR DESCRIPTION
Sorry I really should've done this with the recent #350 but after having merged that I realized I should do a sweep of this thing in the entire codebase and found a few more occurrences that can be improved. Hence this PR.