### PR TITLE
fix: potentially pushing a skill multiple times for scheduled changes

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -96,7 +96,7 @@
 	q.scheduleChange <- function( _field, _change, _set = false )
 	{
 		this.m.ScheduledChanges.push({Field = _field, Change = _change, Set = _set});
-		if (this.getContainer().m.ScheduledChangesSkills.find(this) != null)
+		if (this.getContainer().m.ScheduledChangesSkills.find(this) == null)
 			this.getContainer().m.ScheduledChangesSkills.push(this);
 	}
 

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -96,7 +96,8 @@
 	q.scheduleChange <- function( _field, _change, _set = false )
 	{
 		this.m.ScheduledChanges.push({Field = _field, Change = _change, Set = _set});
-		this.getContainer().m.ScheduledChangesSkills.push(this);
+		if (this.getContainer().m.ScheduledChangesSkills.find(this) != null)
+			this.getContainer().m.ScheduledChangesSkills.push(this);
 	}
 
 	q.executeScheduledChanges <- function()


### PR DESCRIPTION
This wasn't really causing any issues currently because the scheduled changes are cleared the first time they are run, but for complete sanity this check should be baked in.