### PR TITLE
Refactor tile getNeighbor functions

### DIFF
--- a/msu/utils/tile.nut
+++ b/msu/utils/tile.nut
@@ -13,21 +13,13 @@
 		return true;
 	}
 
-	function getNeighbors( _tile, _function = null )
+	function getNeighbors( _tile )
 	{
-		// _function( tile ) returns boolean
-		// iterates over all neighboring tiles and calls _function on each tile
-		// returns an array of tiles for which _function returned true
-
 		local ret = [];
 		for (local i = 0; i < 6; i++)
 		{
 			if (_tile.hasNextTile(i))
-			{
-				local nextTile = _tile.getNextTile();
-				if (_function == null || _function(nextTile))
-					ret.push(nextTile);
-			}
+				ret.push(_tile.getNextTile());
 		}
 		return ret;
 	}
@@ -49,8 +41,8 @@
 		}
 	}
 
-	function getRandomNeighbor( _tile, _function = null )
+	function getRandomNeighbor( _tile )
 	{
-		return ::MSU.Array.rand(this.getNeighbors(_tile, _function));
+		return ::MSU.Array.rand(this.getNeighbors(_tile));
 	}
 }

--- a/msu/utils/tile.nut
+++ b/msu/utils/tile.nut
@@ -23,26 +23,4 @@
 		}
 		return ret;
 	}
-
-	function getNeighbor( _tile, _function = null )
-	{
-		// _function( tile ) returns boolean
-		// iterates over all neighboring tiles and calls _function on each tile
-		// returns the first tile for which _function returned true
-
-		for (local i = 0; i < 6; i++)
-		{
-			if (_tile.hasNextTile(i))
-			{
-				local nextTile = _tile.getNextTile(i);
-				if (_function == null || _function(nextTile))
-					return nextTile;
-			}
-		}
-	}
-
-	function getRandomNeighbor( _tile )
-	{
-		return ::MSU.Array.rand(this.getNeighbors(_tile));
-	}
 }


### PR DESCRIPTION
As per discussion on Discord. These features which were added for the 1.3.0 build before release are being changed. Reasoning 
being:
1. Remove `_function` because the native `filter` can be used on the returned array. And performance isn't a concern.
2. Remove `getNeighbor` as it was returning the first valid neighbor. But that can be achieved in other ways and is a niche application.
3. Remove `getRandomNeighbor` as that can simply be achieved via `::MSU.Array.rand` on `getNeighbors`.
