### PR TITLE
revert: "feat: add getItemsByFunction and getItemsByFunctionAtSlot (#323)"

### DIFF
--- a/msu/hooks/items/item_container.nut
+++ b/msu/hooks/items/item_container.nut
@@ -92,19 +92,4 @@
 
 		return __original(_item);
 	}
-
-	q.getItemsByFunction <- function( _function )
-	{
-		local ret = [];
-		foreach (slot, _ in ::Const.ItemSlotSpaces)
-		{
-			ret.extend(this.getItemsByFunctionAtSlot(slot, _function));
-		}
-		return ret;
-	}
-
-	q.getItemsByFunctionAtSlot <- function( _slot, _function )
-	{
-		return this.m.Items[_slot].filter(@(_, _item) _item != null && _item != -1 && _function(_item));
-	}
 });


### PR DESCRIPTION
As discussed on Discord. We added these features in #323 ahead of the release of 1.3.0 but are removing them before the release.

This reverts commit b3b8ab6ca81f87bf918277f983b404266b1e4467.

Because the functionality added by these functions can be achieved natively by using `.filter` on vanilla `getAllItems` and `getAllItemsAtSlot` functions of item_container.