### PR TITLE
feat: add round function in math utilities to round to nearest multiple

### DIFF
--- a/msu/utils/math.nut
+++ b/msu/utils/math.nut
@@ -39,4 +39,18 @@
 		local magnitude = ::pow(10, _significantFigures - d);
 		return ::Math.round(_num * magnitude) / magnitude;
 	}
+
+	function roundToMult( _num, _multiple )
+	{
+		if (_multiple <= 0)
+		{
+			::logError("_multiple must be greater than 0");
+			throw ::MSU.Exception.InvalidValue(_multiple);
+		}
+
+		local num = ::fabs(_num);
+		local rem = num % _multiple;
+		local ret = rem < _multiple * 0.5 ? num - rem : num + _multiple - rem;
+		return _num < 0 ? -ret : ret;
+	}
 };


### PR DESCRIPTION
Should we call it `round` or something else e.g. `roundToMultiple` or `roundToNearest`?