### PR TITLE
fix: costs preview not calling the original early enough

### DIFF
--- a/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
+++ b/msu/hooks/ui/screens/tactical/modules/turn_sequence_bar/turn_sequence_bar.nut
@@ -32,6 +32,15 @@
 
 	q.setActiveEntityCostsPreview = @(__original) function( _costsPreview )
 	{
+		// The original function also updates the UI, but we don't want to do that yet,
+		// we want to do that after our skill container affordability event has run.
+		// If we don't switcheroo to disable it here, then we'd need to manually call `updateCostsPreview`
+		// on the JSHandle at the end again, and this can lead to slightly glitchy UI animation due to double updating.
+		this.m.MSU_JSHandle.__JSHandle = this.m.JSHandle;
+		this.m.JSHandle = this.m.MSU_JSHandle;
+		__original(_costsPreview);
+		this.m.JSHandle = this.m.MSU_JSHandle.__JSHandle;
+
 		if (::MSU.Mod.ModSettings.getSetting("ExpandedSkillTooltips").getValue())
 		{
 			local activeEntity = this.getActiveEntity();
@@ -52,10 +61,6 @@
 			}
 		}
 
-		this.m.MSU_JSHandle.__JSHandle = this.m.JSHandle;
-		this.m.JSHandle = this.m.MSU_JSHandle;
-		__original(_costsPreview);
-		this.m.JSHandle = this.m.MSU_JSHandle.__JSHandle;
 		this.m.JSHandle.asyncCall("updateCostsPreview", this.m.ActiveEntityCostsPreview);
 	}
 


### PR DESCRIPTION
The entire point of the switcheroo on JSHandle is so that the original function is called before our skill container event (onAffordablePreview) so that the values set by the original function happen before our event.

This is how it should have been in #313 and how it was in the first implementation of that PR. But in all the refactors switching to switcherooing the JSHandle, it got messed up. Here it is fixed now.