### PR TITLE
fix: table and class cases in deepEquals

### DIFF
--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -162,7 +162,7 @@
 				return false;
 			foreach (k, v in _a)
 			{
-				if (!this.deepEquals(v, _b[k]))
+				if (!(k in _b) || !this.deepEquals(v, _b[k]))
 					return false;
 			}
 			return true;
@@ -176,11 +176,11 @@
 			}
 			return true;
 		case "instance":
-			if (!(_b instanceof _a.getclass()))
+			if (!(typeof b != "instance") || _a.getclass() != _b.getclass())
 				return false;
-			foreach (k, v in _a.getclass())
+			foreach (k, v in _a)
 			{
-				if (!(k in _b) || !this.deepEquals(v, _b[k]))
+				if (!this.deepEquals(v, _b[k]))
 					return false;
 			}
 			return true;

--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -178,7 +178,7 @@
 		case "instance":
 			if (!(typeof _b != "instance") || _a.getclass() != _b.getclass())
 				return false;
-			foreach (k, v in _a)
+			foreach (k, v in _a.getclass())
 			{
 				if (!this.deepEquals(v, _b[k]))
 					return false;

--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -176,7 +176,7 @@
 			}
 			return true;
 		case "instance":
-			if (!(typeof b != "instance") || _a.getclass() != _b.getclass())
+			if (!(typeof _b != "instance") || _a.getclass() != _b.getclass())
 				return false;
 			foreach (k, v in _a)
 			{


### PR DESCRIPTION
- For the table case add check for key existing in _b.
- For the instance case require that the class of both instances is the same.