### PR TITLE
fix(vanilla): sallet helmet using wrong variant in setPlainVariant

### DIFF
--- a/msu/hooks/items/helmets/sallet_helmet.nut
+++ b/msu/hooks/items/helmets/sallet_helmet.nut
@@ -1,0 +1,8 @@
+::Reforged.HooksMod.hook("scripts/items/helmets/sallet_helmet", function(q) {
+	// VANIILLFIX: https://battlebrothersgame.com/forums/topic/wrong-variant-in-setplainvariant-of-sallet_helmet/
+	// https://steamcommunity.com/app/365360/discussions/1/4408543140360563731/
+	q.setPlainVariant = @() function()
+	{
+		this.setVariant(163);
+	}
+});


### PR DESCRIPTION
VANIILLA FIX:
https://battlebrothersgame.com/forums/topic/wrong-variant-in-setplainvariant-of-sallet_helmet/
https://steamcommunity.com/app/365360/discussions/1/4408543140360563731/