### PR TITLE
feat: auto calculate DamageType ratio in skills

### DIFF
--- a/msu/classes/weighted_container_damage_type.nut
+++ b/msu/classes/weighted_container_damage_type.nut
@@ -45,7 +45,7 @@
 					local piercing = ::Const.Injury.PiercingBody.len() + ::Const.Injury.PiercingHead.len();
 					local total = (blunt + piercing).tofloat();
 					this.add(::Const.Damage.DamageType.Blunt, ::MSU.Math.roundToMult(100 * blunt / total, 5)); // We round to the nearest multiple of 5 to make it "cleaner" for players
-					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.roundToMult(100 * blunt / total, 5));
+					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.roundToMult(100 * piercing / total, 5));
 					break;
 
 				case ::Const.Injury.BurningAndPiercingBody:

--- a/msu/classes/weighted_container_damage_type.nut
+++ b/msu/classes/weighted_container_damage_type.nut
@@ -41,18 +41,27 @@
 					break;
 
 				case ::Const.Injury.BluntAndPiercingBody:
-					this.add(::Const.Damage.DamageType.Blunt, 55);
-					this.add(::Const.Damage.DamageType.Piercing, 45);
+					local blunt = ::Const.Injury.BluntBody.len() + ::Const.Injury.BluntHead.len();
+					local piercing = ::Const.Injury.PiercingBody.len() + ::Const.Injury.PiercingHead.len();
+					local total = (blunt + piercing).tofloat();
+					this.add(::Const.Damage.DamageType.Blunt, ::MSU.Math.round(100 * blunt / total, 5)); // We round to the nearest multiple of 5 to make it "cleaner" for players
+					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.round(100 * blunt / total, 5));
 					break;
 
 				case ::Const.Injury.BurningAndPiercingBody:
-					this.add(::Const.Damage.DamageType.Burning, 25);
-					this.add(::Const.Damage.DamageType.Piercing, 75);
+					local burning = ::Const.Injury.BurningBody.len() + ::Const.Injury.BurningHead.len();
+					local piercing = ::Const.Injury.PiercingBody.len() + ::Const.Injury.PiercingHead.len();
+					local total = (burning + piercing).tofloat();
+					this.add(::Const.Damage.DamageType.Burning, ::MSU.Math.round(100 * burning / total, 5));
+					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.round(100 * piercing / total, 5));
 					break;
 
 				case ::Const.Injury.CuttingAndPiercingBody:
-					this.add(::Const.Damage.DamageType.Cutting);
-					this.add(::Const.Damage.DamageType.Piercing);
+					local cutting = ::Const.Injury.CuttingBody.len() + ::Const.Injury.CuttingHead.len();
+					local piercing = ::Const.Injury.PiercingBody.len() + ::Const.Injury.PiercingHead.len();
+					local total = (cutting + piercing).tofloat();
+					this.add(::Const.Damage.DamageType.Cutting, ::MSU.Math.round(100 * cutting / total, 5));
+					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.round(100 * piercing / total, 5));
 					break;
 
 				default:

--- a/msu/classes/weighted_container_damage_type.nut
+++ b/msu/classes/weighted_container_damage_type.nut
@@ -44,24 +44,24 @@
 					local blunt = ::Const.Injury.BluntBody.len() + ::Const.Injury.BluntHead.len();
 					local piercing = ::Const.Injury.PiercingBody.len() + ::Const.Injury.PiercingHead.len();
 					local total = (blunt + piercing).tofloat();
-					this.add(::Const.Damage.DamageType.Blunt, ::MSU.Math.round(100 * blunt / total, 5)); // We round to the nearest multiple of 5 to make it "cleaner" for players
-					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.round(100 * blunt / total, 5));
+					this.add(::Const.Damage.DamageType.Blunt, ::MSU.Math.roundToMult(100 * blunt / total, 5)); // We round to the nearest multiple of 5 to make it "cleaner" for players
+					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.roundToMult(100 * blunt / total, 5));
 					break;
 
 				case ::Const.Injury.BurningAndPiercingBody:
 					local burning = ::Const.Injury.BurningBody.len() + ::Const.Injury.BurningHead.len();
 					local piercing = ::Const.Injury.PiercingBody.len() + ::Const.Injury.PiercingHead.len();
 					local total = (burning + piercing).tofloat();
-					this.add(::Const.Damage.DamageType.Burning, ::MSU.Math.round(100 * burning / total, 5));
-					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.round(100 * piercing / total, 5));
+					this.add(::Const.Damage.DamageType.Burning, ::MSU.Math.roundToMult(100 * burning / total, 5));
+					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.roundToMult(100 * piercing / total, 5));
 					break;
 
 				case ::Const.Injury.CuttingAndPiercingBody:
 					local cutting = ::Const.Injury.CuttingBody.len() + ::Const.Injury.CuttingHead.len();
 					local piercing = ::Const.Injury.PiercingBody.len() + ::Const.Injury.PiercingHead.len();
 					local total = (cutting + piercing).tofloat();
-					this.add(::Const.Damage.DamageType.Cutting, ::MSU.Math.round(100 * cutting / total, 5));
-					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.round(100 * piercing / total, 5));
+					this.add(::Const.Damage.DamageType.Cutting, ::MSU.Math.roundToMult(100 * cutting / total, 5));
+					this.add(::Const.Damage.DamageType.Piercing, ::MSU.Math.roundToMult(100 * piercing / total, 5));
 					break;
 
 				default:


### PR DESCRIPTION
Originally we calculated approximate ratios for these "mixed" damage type skills based on the number of injuries there are in vanilla and hard-coded them as weights in the containers so that the injury inflicting behavior with MSU damage type system corresponds to the probability of injuries in vanilla. However, mods may change the number of different types of injuries, causing this ratio to no longer represent the new ratio of injuries. This PR ensures that the ratio is calculated dynamically.

I have used the MSU.Math.roundToMult function #358 to round it to the nearest multiple of 5. For the case of vanilla this only affects `BluntAndPiercing` which in vanilla was giving a ratio of 58/42 but we had it set at 45/55. The others were already exact at multiples of 5. I believe rounded to the nearest multiple of 5 is still good as it keeps the damage type ratios more "clean" for the players in tooltips.