### PR TITLE
fix: handling for accessing skill DamageType before hookTree

### DIFF
--- a/msu/classes/weighted_container_damage_type.nut
+++ b/msu/classes/weighted_container_damage_type.nut
@@ -68,6 +68,17 @@ foreach (k, v in ::MSU.Class.WeightedContainer)
 		continue;
 
 	local info = v.getinfos();
+
+	foreach (p in info.defparams)
+	{
+		local t = typeof p;
+		if (t == "array" || t == "table" || t == "instance" || t == "class")
+		{
+			::logError(format("WeightedContainer and its parent classes cannot have a function with reference type parameters -- function %s has a parameter with type %s", k, t));
+			throw ::MSU.Exception.InvalidValue(t);
+		}
+	}
+
 	local declarationParams = clone info.parameters; // used in compilestring for function declaration
 	local wrappedParams = clone declarationParams; // used in compilestring to call skills function
 
@@ -78,7 +89,7 @@ foreach (k, v in ::MSU.Class.WeightedContainer)
 	}
 	else // function with vargv cannot have defparams
 	{
-		foreach (i, defparam in info.defparams) // We don't add handling for ref-type defparams. We expect our parent classes to not have such functions.
+		foreach (i, defparam in info.defparams)
 		{
 			if (defparam == null)
 				defparam = "null";

--- a/msu/classes/weighted_container_damage_type.nut
+++ b/msu/classes/weighted_container_damage_type.nut
@@ -80,7 +80,7 @@ foreach (k, v in ::MSU.Class.WeightedContainer)
 	}
 
 	local declarationParams = clone info.parameters; // used in compilestring for function declaration
-	local wrappedParams = clone declarationParams; // used in compilestring to call skills function
+	local wrappedParams = clone declarationParams; // used in compilestring to call base function
 
 	if (declarationParams[declarationParams.len() - 1] == "...")
 	{

--- a/msu/classes/weighted_container_damage_type.nut
+++ b/msu/classes/weighted_container_damage_type.nut
@@ -78,7 +78,7 @@ foreach (k, v in ::MSU.Class.WeightedContainer)
 	}
 	else // function with vargv cannot have defparams
 	{
-		foreach (i, defparam in info.defparams)
+		foreach (i, defparam in info.defparams) // We don't add handling for ref-type defparams. We expect our parent classes to not have such functions.
 		{
 			if (defparam == null)
 				defparam = "null";
@@ -92,6 +92,5 @@ foreach (k, v in ::MSU.Class.WeightedContainer)
 	declarationParams = declarationParams.len() == 0 ? "" : declarationParams.reduce(@(a, b) a + ", " + b);
 	wrappedParams = wrappedParams.len() == 0 ? "" : wrappedParams.reduce(@(a, b) a + ", " + b);
 
-	local str = format("return function (%s) { this.doInit(); return base.%s(%s); }", declarationParams, k, wrappedParams);
-	::MSU.Class.DamageType[k] <- compilestring(str)();
+	::MSU.Class.DamageType[k] <- compilestring(format("return function (%s) { this.doInit(); return base.%s(%s); }", declarationParams, k, wrappedParams))();
 }

--- a/msu/classes/weighted_container_damage_type.nut
+++ b/msu/classes/weighted_container_damage_type.nut
@@ -1,0 +1,97 @@
+::MSU.Class.DamageType <- class extends ::MSU.Class.WeightedContainer
+{
+	__Skill = null;
+	__IsInitDone = true;
+
+	function setSkill( _skill )
+	{
+		this.__Skill = ::MSU.asWeakTableRef(_skill);
+		this.__IsInitDone = false;
+	}
+
+	function doInit()
+	{
+		if (this.__IsInitDone || ::MSU.isNull(this.__Skill))
+			return;
+
+		this.__IsInitDone = true;
+
+		if (this.__Skill.m.IsAttack && this.len() == 0)
+		{
+			switch (this.__Skill.m.InjuriesOnBody)
+			{
+				case null:
+					this.add(::Const.Damage.DamageType.None);
+					break;
+
+				case ::Const.Injury.BluntBody:
+					this.add(::Const.Damage.DamageType.Blunt);
+					break;
+
+				case ::Const.Injury.PiercingBody:
+					this.add(::Const.Damage.DamageType.Piercing);
+					break;
+
+				case ::Const.Injury.CuttingBody:
+					this.add(::Const.Damage.DamageType.Cutting);
+					break;
+
+				case ::Const.Injury.BurningBody:
+					this.add(::Const.Damage.DamageType.Burning);
+					break;
+
+				case ::Const.Injury.BluntAndPiercingBody:
+					this.add(::Const.Damage.DamageType.Blunt, 55);
+					this.add(::Const.Damage.DamageType.Piercing, 45);
+					break;
+
+				case ::Const.Injury.BurningAndPiercingBody:
+					this.add(::Const.Damage.DamageType.Burning, 25);
+					this.add(::Const.Damage.DamageType.Piercing, 75);
+					break;
+
+				case ::Const.Injury.CuttingAndPiercingBody:
+					this.add(::Const.Damage.DamageType.Cutting);
+					this.add(::Const.Damage.DamageType.Piercing);
+					break;
+
+				default:
+					this.add(::Const.Damage.DamageType.Unknown);
+			}
+		}
+	}
+}
+
+foreach (k, v in ::MSU.Class.WeightedContainer)
+{
+	if (typeof v != "function")
+		continue;
+
+	local info = v.getinfos();
+	local declarationParams = clone info.parameters; // used in compilestring for function declaration
+	local wrappedParams = clone declarationParams; // used in compilestring to call skills function
+
+	if (declarationParams[declarationParams.len() - 1] == "...")
+	{
+		declarationParams.remove(declarationParams.len() - 2); // remove "vargv"
+		wrappedParams.remove(wrappedParams.len() - 1); // remove "..."
+	}
+	else // function with vargv cannot have defparams
+	{
+		foreach (i, defparam in info.defparams)
+		{
+			if (defparam == null)
+				defparam = "null";
+
+			declarationParams[declarationParams.len() - info.defparams.len() + i] += " = " + defparam;
+		}
+	}
+
+	declarationParams.remove(0); // remove "this"
+	wrappedParams.remove(0); // remove "this"
+	declarationParams = declarationParams.len() == 0 ? "" : declarationParams.reduce(@(a, b) a + ", " + b);
+	wrappedParams = wrappedParams.len() == 0 ? "" : wrappedParams.reduce(@(a, b) a + ", " + b);
+
+	local str = format("return function (%s) { this.doInit(); return base.%s(%s); }", declarationParams, k, wrappedParams);
+	::MSU.Class.DamageType[k] <- compilestring(str)();
+}

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -4,53 +4,15 @@
 
 	q.create = @(__original) function()
 	{
-		__original();
 		if (this.m.DamageType == null)
-			this.m.DamageType = ::MSU.Class.WeightedContainer();
-
-		if (this.m.IsAttack && this.m.DamageType.len() == 0)
 		{
-			switch (this.m.InjuriesOnBody)
-			{
-				case null:
-					this.m.DamageType.add(::Const.Damage.DamageType.None);
-					break;
-
-				case ::Const.Injury.BluntBody:
-					this.m.DamageType.add(::Const.Damage.DamageType.Blunt);
-					break;
-
-				case ::Const.Injury.PiercingBody:
-					this.m.DamageType.add(::Const.Damage.DamageType.Piercing);
-					break;
-
-				case ::Const.Injury.CuttingBody:
-					this.m.DamageType.add(::Const.Damage.DamageType.Cutting);
-					break;
-
-				case ::Const.Injury.BurningBody:
-					this.m.DamageType.add(::Const.Damage.DamageType.Burning);
-					break;
-
-				case ::Const.Injury.BluntAndPiercingBody:
-					this.m.DamageType.add(::Const.Damage.DamageType.Blunt, 55);
-					this.m.DamageType.add(::Const.Damage.DamageType.Piercing, 45);
-					break;
-
-				case ::Const.Injury.BurningAndPiercingBody:
-					this.m.DamageType.add(::Const.Damage.DamageType.Burning, 25);
-					this.m.DamageType.add(::Const.Damage.DamageType.Piercing, 75);
-					break;
-
-				case ::Const.Injury.CuttingAndPiercingBody:
-					this.m.DamageType.add(::Const.Damage.DamageType.Cutting);
-					this.m.DamageType.add(::Const.Damage.DamageType.Piercing);
-					break;
-
-				default:
-					this.m.DamageType.add(::Const.Damage.DamageType.Unknown);
-			}
+			this.m.DamageType = ::MSU.Class.DamageType();
+			this.m.DamageType.setSkill(this);
 		}
+
+		__original();
+
+		this.m.DamageType.doInit();
 	}
 });
 


### PR DESCRIPTION
Add a new class for DamageType that extends WeightedContainer and overwrites all functions to first initialize the DamageType of the skill before returning the base function. This ensures that hooks on the skill's create function before hookTree that try to add/remove a DamageType or try to access any other value related to the skill's DamageType do not break the auto-assigning of DamageTypes for skills that don't come with DamageType defined (e.g. vanilla skills).