### PR TITLE
Fix handling for ref type defparams in addEvent skills function

### DIFF
--- a/msu/utils/skills.nut
+++ b/msu/utils/skills.nut
@@ -39,6 +39,9 @@
 				{
 					foreach (i, defparam in info.defparams)
 					{
+						if (defparam == null)
+							defparam = "null";
+
 						declarationParams[declarationParams.len() - info.defparams.len() + i] += " = " + defparam;
 					}
 				}

--- a/msu/utils/skills.nut
+++ b/msu/utils/skills.nut
@@ -26,6 +26,15 @@
 			else
 			{
 				local info = _function.getinfos();
+				foreach (p in info.defparams)
+				{
+					local t = typeof p;
+					if (t == "array" || t == "table" || t == "instance" || t == "class")
+					{
+						::logError("addEvent cannot be used to add functions with reference type defparams");
+						throw ::MSU.Exception.InvalidValue(t);
+					}
+				}
 				local declarationParams = clone info.parameters; // used in compilestring for function declaration
 				declarationParams.remove(0) // remove "this"
 				local wrappedParams = clone declarationParams; // used in compilestring to call skills function


### PR DESCRIPTION
- Handling for null defparam is a bugfix and should be added.
- Other ref-type params are something we can't deal with (without adding a custom wrapper with vargv, which I don't want to do here) so we simply disallow the usage of this function to add those kinds of functions. They can be added by modders in the old school manual way to add skill events.