### PR TITLE
fix: FatigueCost getting wrong base value during equipping weapon

### DIFF
--- a/msu/hooks/items/weapons/weapon.nut
+++ b/msu/hooks/items/weapons/weapon.nut
@@ -31,6 +31,9 @@
 		}
 		if (_skill.isType(::Const.SkillType.Active))
 		{
+			// We reset the FatigueCost so any modifications to it from other skills is reverted
+			// the latter part is a copy of the vanilla code applying FatigueOnSkillUse
+			// which we then include in the skill's base fatigue cost (so that orc weapon skills get the proper fatigue cost)
 			_skill.resetField("FatigueCost");
 			local fatigueOnSkillUse = this.getContainer().getActor().getCurrentProperties().IsProficientWithHeavyWeapons && this.m.FatigueOnSkillUse > 0 ? 0 : this.m.FatigueOnSkillUse;
 			local fatCost = ::Math.max(0, _skill.getFatigueCostRaw() + fatigueOnSkillUse);

--- a/msu/hooks/items/weapons/weapon.nut
+++ b/msu/hooks/items/weapons/weapon.nut
@@ -29,6 +29,14 @@
 			_skill.m.AdditionalAccuracy += this.m.AdditionalAccuracy;
 			_skill.setBaseValue("AdditionalAccuracy", _skill.m.AdditionalAccuracy);
 		}
+		if (_skill.isType(::Const.SkillType.Active))
+		{
+			_skill.resetField("FatigueCost");
+			local fatigueOnSkillUse = this.getContainer().getActor().getCurrentProperties().IsProficientWithHeavyWeapons && this.m.FatigueOnSkillUse > 0 ? 0 : this.m.FatigueOnSkillUse;
+			local fatCost = ::Math.max(0, _skill.getFatigueCostRaw() + fatigueOnSkillUse);
+			_skill.setFatigueCost(fatCost);
+			_skill.setBaseValue("FatigueCost", fatCost);
+		}
 		return ret;
 	}
 

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -209,14 +209,6 @@
 		}
 	}
 
-	// TODO: Should probably switch to a hookTree VeryLateBucket
-	// TODO: Should call the original before setting the base value
-	q.setFatigueCost = @(__original) function( _f )
-	{
-		this.setBaseValue("FatigueCost", _f);
-		return __original(_f);
-	}
-
 	q.onMovementStarted <- function( _tile, _numTiles )
 	{
 	}


### PR DESCRIPTION
If the actor has a skill which modifies the weapon skills' FatigueCost field in e.g. onAfterUpdate function. This was happening because an update cycle happened during the call to the original `addSkill`, which also calls setFatigueCost and our hook on `setFatigueCost` was also setting the base value to the given cost. The latter is bad from a principle pov too because setting a skill's FatigueCost shouldn't modify its base fatigue cost.