### PR TITLE
fix: vanilla bb code toggle not applying to text bolded using JS

### DIFF
--- a/msu/msu_mod/msu_mod_modsettings.nut
+++ b/msu/msu_mod/msu_mod_modsettings.nut
@@ -21,8 +21,9 @@ local blockSQInput = generalPage.addBooleanSetting("blockSQInput", true, "Don't 
 blockSQInput.setDescription("Whether keybinds should be blocked when you are writing text.\nBy default, writing text in something like a 'change name' popup will still allow normal game keybinds to work. For example, writing a 'c' would open the stash screen.\nMSU disables game keybinds when you're writing something, but there might be issues with some mods.\nKeep this enabled unless you're having issues with keybinds not working properly.");
 blockSQInput.addAfterChangeCallback(@ (_oldValue) ::MSU.System.Keybinds.InputDenied = false); // use it as an opportunity to reset
 
-local vanillaBBCode = generalPage.addBooleanSetting("VanillaBBCode", false, "Enable Italic/Bold Vanilla Text");
-vanillaBBCode.setDescription("Toggles vanilla bold/italic font modifications being applied, in vanilla these don't work, but are still in the code for some reason, when MSU fixes this behavior to work for mods, suddenly these will apply in vanilla as well.\nThis will make some text look [mb]Bold[/mb] and [mi]Italic[/mi].\n\nSome text may require a restart after toggling this setting.");
+local vanillaBBCode = generalPage.addBooleanSetting("VanillaBBCode", false, "Enable Bold Vanilla Text");
+vanillaBBCode.setDescription("Toggles vanilla bold font modifications being applied, in vanilla these don't work, but are still in the code for some reason, when MSU fixes this behavior to work for mods, suddenly these will apply in vanilla as well.\nThis will make some text look [mb]Bold[/mb].");
+vanillaBBCode.addCallback(@ (_value) ::MSU.UI.JSConnection.onVanillaBBCodeUpdated(_value));
 
 local logPage = ::MSU.Mod.ModSettings.addPage("Logging");
 

--- a/msu/ui/load.nut
+++ b/msu/ui/load.nut
@@ -1,8 +1,7 @@
 ::Hooks.registerJS("ui/mods/msu/popup.js");
-::Hooks.registerCSS("ui/mods/msu/css/popup.css");
 
-::Hooks.registerCSS("ui/mods/msu/css/misc.css");
-::Hooks.registerCSS("ui/mods/msu/css/settings_screen.css");
+foreach (file in ::IO.enumerateFiles("ui/mods/msu/css/"))
+	::Hooks.registerCSS(file + ".css");
 
 ::Hooks.registerJS("ui/mods/msu/utilities.js");
 

--- a/scripts/mods/msu/msu_connection.nut
+++ b/scripts/mods/msu/msu_connection.nut
@@ -1,11 +1,18 @@
 this.msu_connection <- ::inherit("scripts/mods/msu/js_connection", {
-	m = {},
+	m = {
+		FunctionBuffer = []
+	},
 
 	function connect()
 	{
 		this.m.JSHandle = ::UI.connect("MSUConnection", this);
 		this.querySettingsData();
 		this.checkForModUpdates();
+		foreach (fn in this.m.FunctionBuffer)
+		{
+			fn();
+		}
+		this.m.FunctionBuffer.clear();
 	}
 
 	function querySettingsData()
@@ -51,5 +58,19 @@ this.msu_connection <- ::inherit("scripts/mods/msu/js_connection", {
 	function compareModVersions( _modVersionData )
 	{
 		return ::MSU.System.Registry.checkIfModVersionsAreNew(_modVersionData);
+	}
+
+	function onVanillaBBCodeUpdated( _bool )
+	{
+		if (this.m.JSHandle != null)
+		{
+			this.m.JSHandle.asyncCall("onVanillaBBCodeUpdated", _bool);
+		}
+		else
+		{
+			this.m.FunctionBuffer.push(function() {
+				this.onVanillaBBCodeUpdated(_bool);
+			});
+		}
 	}
 });

--- a/ui/mods/msu/css/misc.css
+++ b/ui/mods/msu/css/misc.css
@@ -120,6 +120,18 @@
 	font-family: 'Cinzel', monospace;
 }
 
+.msu-font-mb
+.msu-font-bold
+{
+	font-weight: bold !important;
+}
+
+.msu-font-mi
+.msu-font-italic
+{
+	font-style: italic !important;
+}
+
 /* Outline for debugging */
 .line
 {

--- a/ui/mods/msu/css/vanilla_font_unbold.css
+++ b/ui/mods/msu/css/vanilla_font_unbold.css
@@ -1,0 +1,5 @@
+/* unbolds all vanilla fonts except for title-fonts to maintain vanilla behavior */
+.font-bold:not([class*="title-font"])
+{
+	font-weight: normal !important;
+}

--- a/ui/mods/msu/msu_connection.js
+++ b/ui/mods/msu/msu_connection.js
@@ -162,4 +162,18 @@ MSUConnection.prototype.showModUpdates = function (_modVersionData)
 	MSU.Popup.setState(MSU.Popup.mState.Small);
 }
 
+// this should be reworked if/when we added JS side settings callbacks
+MSUConnection.prototype.onVanillaBBCodeUpdated = function (_bool)
+{
+	var elements = document.getElementsByTagName('link');
+	for (var i = 0; i < elements.length; i++)
+	{
+		if (elements[i].href.indexOf("ui/mods/msu/css/vanilla_font_unbold.css") != -1)
+		{
+			elements[i].disabled = _bool;
+			break;
+		}
+	}
+}
+
 registerScreen("MSUConnection", new MSUConnection());

--- a/ui/mods/msu/ui_hooks/xbbcode.js
+++ b/ui/mods/msu/ui_hooks/xbbcode.js
@@ -1,10 +1,7 @@
 MSU.Hooks.XBBCODE_process = XBBCODE.process;
 XBBCODE.process = function( config )
 {
-	// super ugly hack to get around main menu trying to process xbbcode before settings are set up
-	if ($.isEmptyObject(Screens.ModSettingsScreen.mModSettings) || !MSU.getSettingValue("mod_msu", "VanillaBBCode")) {
-		config.text = config.text.replace(/\[(b|i)\](.*?)\[\/\1\]/gm, "$2");
-	}
-	config.text = config.text.replace(/\[m(b|i)\](.*?)\[\/m\1\]/gm, "[$1]$2[\/$1]");
-	return MSU.Hooks.XBBCODE_process(config);
+	var ret = MSU.Hooks.XBBCODE_process(config);
+	ret.html = ret.html.replace(/(?:\[|&#91;)(mi|mb)(?:\]|&#93;)(.*?)(?:\[|&#91;)\/\1(?:\]|&#93;)/gm, '<class="msu-font-$1">$2</>');
+	return ret;
 }


### PR DESCRIPTION
Went for a different approach with this one which is imo cleaner, previously only text bolded using bbcode would be unbolded, but it turns out vanilla actually bolds some text directly with JS, this is able to handle all those cases. I had to exclude title fonts as those are always bold.