### PR TITLE
refactor: streamline certain load files to include entire folders

### DIFF
--- a/msu/msu_mod/load.nut
+++ b/msu/msu_mod/load.nut
@@ -3,8 +3,5 @@ local function includeFile( _file )
 	::MSU.includeFile("msu/msu_mod/", _file + ".nut");
 }
 includeFile("setup_msu_mod");
-includeFile("msu_registry");
 includeFile("msu_mod_debug");
-includeFile("msu_mod_modsettings");
-includeFile("msu_tooltips");
-includeFile("msu_keybinds");
+::MSU.includeFiles(::IO.enumerateFiles("msu/msu_mod"));

--- a/msu/systems/debug/debug_mod_addon.nut
+++ b/msu/systems/debug/debug_mod_addon.nut
@@ -20,22 +20,22 @@
 		::MSU.System.Debug.setFlags(this.Mod.getID(), _flagTable);
 	}
 
-	function isEnabled( _flagID = ::MSU.System.Debug.DefaultFlag )
+	function isEnabled( _flagID = ::MSU.Class.DebugSystem.DefaultFlag )
 	{
 		return ::MSU.System.Debug.isEnabledForMod(this.Mod.getID(), _flagID);
 	}
 
-	function printLog( _text, _flagID = ::MSU.System.Debug.DefaultFlag )
+	function printLog( _text, _flagID = ::MSU.Class.DebugSystem.DefaultFlag )
 	{
 		::MSU.System.Debug.print(_text, this.Mod.getID(), ::MSU.System.Debug.LogType.Info, _flagID);
 	}
 
-	function printWarning( _text, _flagID = ::MSU.System.Debug.DefaultFlag )
+	function printWarning( _text, _flagID = ::MSU.Class.DebugSystem.DefaultFlag )
 	{
 		::MSU.System.Debug.print(_text, this.Mod.getID(), ::MSU.System.Debug.LogType.Warning, _flagID);
 	}
 
-	function printError( _text, _flagID = ::MSU.System.Debug.DefaultFlag )
+	function printError( _text, _flagID = ::MSU.Class.DebugSystem.DefaultFlag )
 	{
 		::MSU.System.Debug.print(_text, this.Mod.getID(), ::MSU.System.Debug.LogType.Error, _flagID);
 	}

--- a/msu/systems/debug/load.nut
+++ b/msu/systems/debug/load.nut
@@ -1,5 +1,10 @@
-::MSU.includeFile("msu/systems/debug/", "debug_system.nut");
+local function includeFile(_file)
+{
+	::MSU.includeFile("msu/systems/debug/", _file);
+}
+
+includeFile("debug_system");
+includeFile("debug_mod_addon");
+::MSU.includeFiles(::IO.enumerateFiles("msu/systems/debug"));
 
 ::MSU.System.Debug <- ::MSU.Class.DebugSystem();
-
-::MSU.includeFile("msu/systems/debug/", "debug_mod_addon.nut");

--- a/msu/systems/keybinds/load.nut
+++ b/msu/systems/keybinds/load.nut
@@ -5,10 +5,10 @@ function includeFile( _file )
 
 includeFile("key_static");
 includeFile("abstract_keybind");
-includeFile("keybind_sq");
-includeFile("keybind_sq_passive");
-includeFile("keybind_js");
 includeFile("keybinds_system");
+includeFile("keybinds_mod_addon");
+::MSU.includeFiles(::IO.enumerateFiles("msu/systems/keybinds"));
+
 ::MSU.System.Keybinds <- ::MSU.Class.KeybindsSystem();
 ::MSU.UI.addOnConnectCallback(::MSU.System.Keybinds.frameUpdate.bindenv(::MSU.System.Keybinds));
 local clearEvents = ::Time.clearEvents;
@@ -17,5 +17,3 @@ local clearEvents = ::Time.clearEvents;
 	clearEvents();
 	::MSU.System.Keybinds.frameUpdate()
 }
-includeFile("keybinds_mod_addon");
-

--- a/msu/systems/mod_settings/load.nut
+++ b/msu/systems/mod_settings/load.nut
@@ -12,16 +12,15 @@ foreach (file in ::IO.enumerateFiles("msu/systems/mod_settings/elements/"))
 	::include(file);
 }
 
-includeFile("settings_page.nut");
-includeFile("settings_panel.nut");
+includeFile("mod_settings_system");
+includeFile("mod_settings_mod_addon");
+::MSU.includeFiles(::IO.enumerateFiles("msu/systems/mod_settings"));
 
-includeFile("mod_settings_system.nut");
 ::MSU.System.ModSettings <- ::MSU.Class.ModSettingsSystem();
 ::getModSetting <- function( _modID, _settingID )
 {
 	return ::MSU.System.ModSettings.getPanel(_modID).getSetting(_settingID);
 }
-includeFile("mod_settings_mod_addon.nut");
 
 ::MSU.SettingsScreen <- ::new("scripts/mods/msu/settings_screen");
 ::MSU.UI.registerConnection(::MSU.SettingsScreen);

--- a/msu/systems/persistent_data/load.nut
+++ b/msu/systems/persistent_data/load.nut
@@ -1,5 +1,10 @@
-::MSU.includeFile("msu/systems/persistent_data/", "persistent_data_system.nut");
+local function includeFile(_file)
+{
+	::MSU.includeFile("msu/systems/persistent_data/", _file);
+}
+
+includeFile("persistent_data_system");
+includeFile("persistent_data_mod_addon");
+::MSU.includeFiles(::IO.enumerateFiles("msu/systems/persistent_data"));
 
 ::MSU.System.PersistentData <- ::MSU.Class.PersistentDataSystem();
-
-::MSU.includeFile("msu/systems/persistent_data/", "persistent_data_mod_addon.nut");

--- a/msu/systems/registry/load.nut
+++ b/msu/systems/registry/load.nut
@@ -1,18 +1,15 @@
-local function includeFile( _file )
+local function includeFile(_file)
 {
 	::MSU.includeFile("msu/systems/registry/", _file);
 }
+
 includeFile("registry_system");
 includeFile("registry_mod_addon");
+::MSU.includeFiles(::IO.enumerateFiles("msu/systems/registry"))
 
-local system = ::MSU.Class.RegistrySystem();
-::MSU.System.Registry <- system;
-
-::includeFiles(::IO.enumerateFiles("msu/systems/registry/mod_sources"))
-
+::MSU.System.Registry <- ::MSU.Class.RegistrySystem();
 ::MSU.System.Registry.addNewModSource(::MSU.Class.ModSourceGitHub);
 ::MSU.System.Registry.addNewModSource(::MSU.Class.ModSourceNexusMods);
-
 ::MSU.getMod <- function( _modID )
 {
 	return ::MSU.System.Registry.getMod(_modID);

--- a/msu/systems/registry/mod_sources/mod_source_github.nut
+++ b/msu/systems/registry/mod_sources/mod_source_github.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.ModSourceGitHub <- class extends ::MSU.Class.ModSource
 {
-	static ModSourceDomain = ::MSU.System.Registry.ModSourceDomain.GitHub;
+	static ModSourceDomain = ::MSU.Class.RegistrySystem.ModSourceDomain.GitHub;
 	static Regex = regexp("https:\\/\\/github\\.com\\/([-\\w]+)\\/([-\\w]+)");
 
 	constructor( _url )

--- a/msu/systems/registry/mod_sources/mod_source_nexusmods.nut
+++ b/msu/systems/registry/mod_sources/mod_source_nexusmods.nut
@@ -1,6 +1,6 @@
 ::MSU.Class.ModSourceNexusMods <- class extends ::MSU.Class.ModSource
 {
-	static ModSourceDomain = ::MSU.System.Registry.ModSourceDomain.NexusMods;
+	static ModSourceDomain = ::MSU.Class.RegistrySystem.ModSourceDomain.NexusMods;
 	static Regex = regexp("https:\\/\\/www\\.nexusmods\\.com\\/battlebrothers\\/mods\\/(\\d+)");
 
 	constructor( _url )

--- a/msu/systems/serialization/load.nut
+++ b/msu/systems/serialization/load.nut
@@ -5,16 +5,11 @@ function includeFile( _file )
 includeFile("metadata_emulator");
 includeFile("serde_emulator");
 includeFile("flag_serde_emulator");
-includeFile("flag_serialization_emulator");
-includeFile("flag_deserialization_emulator");
-includeFile("serialization_emulator");
-includeFile("deserialization_emulator");
+includeFile("serialization_system");
+includeFile("serialization_mod_addon");
+::MSU.includeFiles(::IO.enumerateFiles("msu/systems/serialization"));
 
-includeFile("serialization_system.nut");
 ::MSU.System.Serialization <- ::MSU.Class.SerializationSystem();
-includeFile("serialization_mod_addon.nut");
-
-::MSU.includeFiles(::IO.enumerateFiles("msu/systems/serialization/serialization_types"));
 
 ::MSU.QueueBucket.AfterHooks.push(function() {
 	local worldState = ::new("scripts/states/world_state");

--- a/msu/systems/tooltips/load.nut
+++ b/msu/systems/tooltips/load.nut
@@ -3,8 +3,9 @@ local function includeFile(_file)
 	::MSU.includeFile("msu/systems/tooltips/", _file);
 }
 
-includeFile("tooltips_system");
-::MSU.System.Tooltips <- ::MSU.Class.TooltipsSystem();
-includeFile("tooltips_mod_addon");
 includeFile("abstract_tooltip");
-::MSU.includeFiles(::IO.enumerateFiles("msu/systems/tooltips/tooltips"));
+includeFile("tooltips_system");
+includeFile("tooltips_mod_addon");
+::MSU.includeFiles(::IO.enumerateFiles("msu/systems/tooltips"));
+
+::MSU.System.Tooltips <- ::MSU.Class.TooltipsSystem();

--- a/msu/vanilla_mod/load.nut
+++ b/msu/vanilla_mod/load.nut
@@ -3,6 +3,6 @@ local function includeFile( _file )
 	::MSU.includeFile("msu/vanilla_mod/", _file + ".nut");
 }
 includeFile("setup_vanilla_mod");
-includeFile("vanilla_keybinds");
+::MSU.includeFiles(::IO.enumerateFiles("msu/vanilla_mod"));
 
 


### PR DESCRIPTION
So that MSU modules outside the MSU zip which are trying to add or modify classes in these folders are able to do that before the classes are instantiated.