### PR TITLE
feat: add utility function for benchmarking

### DIFF
--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -231,6 +231,7 @@
 			};
 		}
 
+		::logWarning("MSU -- Benchmark with " + _iterations + " iterations");
 		foreach (i, entry in times)
 		{
 			local diff = entry.TimePerIteration - times[0].TimePerIteration;

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -236,11 +236,11 @@
 			local diff = entry.TimePerIteration - times[0].TimePerIteration;
 			local color = i == 0 ? "" : (diff <= 0 ? "green" : "red"); // the base function is printed without color, faster in green, slower in red
 
-			local timePerIterationText = format("<div style='display: inline-block; color:%s;'>%f (%s%f)</div>", color, entry.TimePerIteration, diff >= 0 ? "+" : "", diff);
+			local timePerIterationText = format("<span style='color:%s;'>%f (%s%f)</span>", color, entry.TimePerIteration, diff >= 0 ? "+" : "", diff);
 			diff = entry.TotalTime - times[0].TotalTime;
 			local totalTimeText = entry.TotalTime + (diff < 0 ? " (" : " (+") + diff + ")";
-			local timePctText = format("<div style='display: inline-block; color:%s'>%i%% %s</div>", color, ::Math.abs(100 * diff / times[0].TotalTime), diff < 0 ? "faster" : "slower");
-			::logInfo(format("<div style='display: inline-block;'>%s: %s ms (Total: %s ms) -- %s</div>", _functions[i][0] + "", timePerIterationText, totalTimeText, i == 0 ? "base time" : timePctText));
+			local timePctText = format("<span style='color:%s;'>%i%% %s</span>", color, ::Math.abs(100 * diff / times[0].TotalTime), diff < 0 ? "faster" : "slower");
+			::logInfo(format("<span>%s: %s ms (Total: %s ms) -- %s</span>", _functions[i][0] + "", timePerIterationText, totalTimeText, i == 0 ? "base time" : timePctText));
 		}
 	}
 

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -203,6 +203,47 @@
 	    return this.Timers[_id];
 	}
 
+	function benchmark( _functions, _iterations = 100000 )
+	{
+		// _functions can be a function to be benchmarked
+		// or an array of len 2 arrays where idx 0 is an id (can be string) and idx 1 is function to be benchmarked
+		if (typeof _functions == "function")
+			_functions = [["", _functions]];
+
+		local times = array(_functions.len());
+		local timer = ::MSU.Class.Timer("MSU_Benchmark");
+
+		foreach (i, entry in _functions)
+		{
+			local timeStart = timer.silentGet();
+			local f = entry[1];
+
+			for (local j = 0; j < _iterations; j++)
+			{
+				f();
+			}
+
+			local totalTime = timer.silentGet() - timeStart;
+
+			times[i] = {
+				TotalTime = totalTime,
+				TimePerIteration = totalTime / _iterations
+			};
+		}
+
+		foreach (i, entry in times)
+		{
+			local diff = entry.TimePerIteration - times[0].TimePerIteration;
+			local color = i == 0 ? "" : (diff <= 0 ? "green" : "red"); // the base function is printed without color, faster in green, slower in red
+
+			local timePerIterationText = format("<div style='display: inline-block; color:%s;'>%f (%s%f)</div>", color, entry.TimePerIteration, diff >= 0 ? "+" : "", diff);
+			diff = entry.TotalTime - times[0].TotalTime;
+			local totalTimeText = entry.TotalTime + (diff < 0 ? " (" : " (+") + diff + ")";
+			local timePctText = format("<div style='display: inline-block; color:%s'>%i%% %s</div>", color, ::Math.abs(100 * diff / times[0].TotalTime), diff < 0 ? "faster" : "slower");
+			::logInfo(format("<div style='display: inline-block;'>%s: %s ms (Total: %s ms) -- %s</div>", _functions[i][0] + "", timePerIterationText, totalTimeText, i == 0 ? "base time" : timePctText));
+		}
+	}
+
 	// Deprecated - use ::MSU.AI.addBehavior instead
 	function addAIBehaviour(_id, _name, _order, _score = null)
 	{

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -211,11 +211,10 @@
 			_functions = [["", _functions]];
 
 		local times = array(_functions.len());
-		local timer = ::MSU.Class.Timer("MSU_Benchmark");
 
 		foreach (i, entry in _functions)
 		{
-			local timeStart = timer.silentGet();
+			local timer = ::MSU.Utils.Timer("MSU_Benchmark");
 			local f = entry[1];
 
 			for (local j = 0; j < _iterations; j++)
@@ -223,7 +222,7 @@
 				f();
 			}
 
-			local totalTime = timer.silentGet() - timeStart;
+			local totalTime = timer.silentStop();
 
 			times[i] = {
 				TotalTime = totalTime,


### PR DESCRIPTION
This is a useful function for benchmarking a single function or comparing the benchmarks of several functions. Usage:

```squirrel
// Let's say we have 3 functions called foo, bar, baz
// we pass them as references in an array and assign them an id that will be printed in log
::MSU.Utils.benchmark([
	["Endy",  foo],
	["Midas", bar],
	["Taro", baz]
]);
```
This will print to log the performance of the 3 functions as well as their relative performance to the first function i.e. in this case `Endy`.

In case your functions need parameters you can manually call them via passing lambdas to the utility function and using local variables as the args:
```squirrel
::MSU.Utils.benchmark([
	["Endy",  @() foo(pass args here)],
	["Midas", @() bar(pass args here)],
	["Taro", @() baz(pass args here)]
]);
```

Sample:
<img width="524" alt="image" src="https://github.com/user-attachments/assets/2e0ff7e9-92ae-4027-816b-a3587f7418b7">
