### PR TITLE
feat: add removeValues function to array utilities

### DIFF
--- a/msu/utils/array.nut
+++ b/msu/utils/array.nut
@@ -64,6 +64,7 @@
 				_array.remove(i);
 			}
 		}
+		return _array;
 	}
 
 	function shuffle( _array )

--- a/msu/utils/array.nut
+++ b/msu/utils/array.nut
@@ -55,6 +55,17 @@
 		if (idx != null) return _array.remove(idx);
 	}
 
+	function removeValues( _array, _values )
+	{
+		for (local i = _array.len() - 1; i >= 0; i--)
+		{
+			if (_values.find(_array[i]) != null)
+			{
+				_array.remove(i);
+			}
+		}
+	}
+
 	function shuffle( _array )
 	{
 		for (local i = _array.len() - 1; i > 0; i--)


### PR DESCRIPTION
This function removes given values from an array in place as opposed to the native filter function that returns a new array. Doing `_values.find` is expected to be faster than first converting `_values` to a local table and then using `in` for each element in `_array`. This is because looking up values that don't exist in a table is a slower operation than using `find` on an array especially at smaller len - which `_values` is expected to have.