### PR TITLE
feat: add colorDamage function to text utilities

### DIFF
--- a/msu/utils/text.nut
+++ b/msu/utils/text.nut
@@ -28,4 +28,9 @@
 	{
 		return this.color(::Const.UI.Color.NegativeValue, _string);
 	}
+
+	function colorDamage( string )
+	{
+		return this.color(::Const.UI.Color.DamageValue, _string);
+	}
 }


### PR DESCRIPTION
I had originally not added this function because I thought it wouldn't be used that often but in my experience I've already had to color text with damage color quite often, so this seems like a worthwhile addition.