### PR TITLE
fix: excluded injuries get function extending array by reference

### DIFF
--- a/msu/hooks/config/character_injuries.nut
+++ b/msu/hooks/config/character_injuries.nut
@@ -1,7 +1,7 @@
 ::Const.Injury.ExcludedInjuries <- {
 	function get( _injuries )
 	{
-		local ret = _injuries.Injuries;
+		local ret = clone _injuries.Injuries;
 
 		foreach (extra in _injuries.Include)
 		{

--- a/msu/hooks/config/character_injuries.nut
+++ b/msu/hooks/config/character_injuries.nut
@@ -5,7 +5,7 @@
 
 		foreach (extra in _injuries.Include)
 		{
-			ret.extend(extra.Injuries);
+			ret.extend(this.get(extra));
 		}
 
 		return ret;


### PR DESCRIPTION
Contains two fixes:
- fix: excluded injuries `get` function extending array by reference
- fix: excluded injuries `get` not including extra injuries of included ones