### PR TITLE
fix: ai paying no AP cost for pick up weapon behavior

### DIFF
--- a/msu/hooks/ai/tactical/behaviors/ai_pickup_weapon.nut
+++ b/msu/hooks/ai/tactical/behaviors/ai_pickup_weapon.nut
@@ -1,0 +1,33 @@
+::MSU.MH.hook("scripts/ai/tactical/behaviors/ai_pickup_weapon", function(q) {
+	q.onExecute = @(__original) function( _entity )
+	{
+		local itemsBefore = array(::Const.ItemSlot.COUNT);
+		for (local i = 0; i < ::Const.ItemSlot.COUNT; i++)
+		{
+			itemsBefore[i] = clone _entity.getItems().m.Items[i];
+		}
+
+		_entity.getItems().m.MSU_IsIgnoringItemAction = true;
+		local ret = __original(_entity);
+		_entity.getItems().m.MSU_IsIgnoringItemAction = false;
+
+		if (ret)
+		{
+			local items = [];
+			for (local i = 0; i < ::Const.ItemSlot.COUNT; i++)
+			{
+				foreach (j, item in _entity.getItems().m.Items[i])
+				{
+					if (item != itemsBefore[i][j] && items.find(item) == null)
+					{
+						if (item != null && item != -1) items.push(item);
+						if (itemsBefore[i][j] != null && itemsBefore[i][j] != -1) items.push(itemsBefore[i][j]);
+					}
+				}
+			}
+			_entity.getItems().payForAction(items);
+		}
+
+		return ret;
+	}
+});


### PR DESCRIPTION
Similar to the fixes we made in #181 but we missed this behavior. I'm thinking now, this doesn't seem perfect because any modder who tries to pay action with an empty array will end up getting wrong behavior (although our [documentation](https://github.com/MSUTeam/MSU/wiki/Item-Actions) on our changes to item action stuff should make it clear that we completely change the system, so there's that).

Is there any other approach we can do to reconsider this thing from scratch? If not, then at least this fix needs to go in. Check my alternative approach in #406 