### PR TITLE
refactor: print specific file instead of full stack trace for invalid data

### DIFF
--- a/msu/systems/serialization/serde_emulator.nut
+++ b/msu/systems/serialization/serde_emulator.nut
@@ -165,7 +165,6 @@
 		{
 			local stackinfos = ::getstackinfos(2);
 			::logError(format("The type being read %s isn't the same as the type %s (with value: %s) stored in the Deserialization Emulator (%s -> %s : %i)", ::MSU.Serialization.DataType.getKeyForValue(_type), ::MSU.Serialization.DataType.getKeyForValue(this.SerializationData.getDataArray()[this.Idx].getType()), data.getData() + "", stackinfos.func == "unknown" ? "" : stackinfos.func, stackinfos.src, stackinfos.line));
-			::MSU.Log.printStackTrace(); // TODO: Temporary, should be removed once log spam issue is resolved
 		}
 		return data.getData();
 	}

--- a/msu/systems/serialization/serialization_types/primitive_data.nut
+++ b/msu/systems/serialization/serialization_types/primitive_data.nut
@@ -76,7 +76,7 @@
 
 	function __printInvalidDataError( _type, _data )
 	{
-		::logError(format("Storing invalid or unexpected data \'%s\' in container of type: %s", _data + "", ::MSU.Serialization.DataType.getKeyForValue(_type)));
+		::logError(format("Storing invalid or unexpected data \'%s\' (type %s) in container of type: %s", _data + "", typeof _data, ::MSU.Serialization.DataType.getKeyForValue(_type)));
 		// We have to print the full stack trace here because we cannot know for sure which level of stackinfos will be the actual source of the problem
 		// as it will be different if this is being instantiated by someone in their own function somewhere or if it is being instantiated
 		// by MSU functions e.g. ::MSU.Serialization.__convertValueFromBaseType

--- a/msu/systems/serialization/serialization_types/primitive_data.nut
+++ b/msu/systems/serialization/serialization_types/primitive_data.nut
@@ -76,10 +76,24 @@
 
 	function __printInvalidDataError( _type, _data )
 	{
-		::logError(format("Storing invalid or unexpected data \'%s\' (type %s) in container of type: %s", _data + "", typeof _data, ::MSU.Serialization.DataType.getKeyForValue(_type)));
-		// We have to print the full stack trace here because we cannot know for sure which level of stackinfos will be the actual source of the problem
-		// as it will be different if this is being instantiated by someone in their own function somewhere or if it is being instantiated
-		// by MSU functions e.g. ::MSU.Serialization.__convertValueFromBaseType
-		::MSU.Log.printStackTrace();
+		local level = 3;
+		local errorSource = "";
+		local infos = ::getstackinfos(level);
+		while (infos != null)
+		{
+			local src = infos.src;
+			if (src.len() < 4 || src.slice(0, 4) != "msu/" || src.len() < 9 || src.slice(0, 9) == "msu/hooks")
+			{
+				errorSource = format(" (%s -> %s : %i)", infos.func == "unknown" ? "" : infos.func, src, infos.line);
+				break;
+			}
+
+			infos = ::getstackinfos(++level);
+		}
+
+		::logError(format("Storing invalid or unexpected data \'%s\' (type %s) in container of type: %s%s", _data + "", typeof _data, ::MSU.Serialization.DataType.getKeyForValue(_type), errorSource));
+
+		if (errorSource == "")
+			::MSU.Log.printStackTrace();
 	}
 }


### PR DESCRIPTION
Also reverts the temporary 44b46fdbdb7da6be555a0f5a52ea6b518be1aa02 as we no longer need to print the full stack trace as the "temporary" situation has been resolved. I am not aware of any current issues in that department.