### PR TITLE
fix: add create to skill and remove contains check from hookTree

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -1,7 +1,4 @@
 ::MSU.MH.hookTree("scripts/skills/skill", function(q) {
-	if (!q.contains("create"))
-		return;
-
 	q.create = @(__original) function()
 	{
 		if (this.m.DamageType == null)
@@ -26,6 +23,12 @@
 
 	q.m.IsApplyingPreview <- false;
 	q.m.PreviewField <- {};
+
+	// Add create function in skill.nut which doesn't exist in vanilla
+	// so hookTree on skill doesn't need a `.contains("create")` check
+	q.create <- function()
+	{
+	}
 
 	q.isType = @() function( _t, _any = true, _only = false )
 	{


### PR DESCRIPTION
The contains check will cause leaf classes which do not have `create` defined to not be properly hooked by our hookTree. The solution to this is to add `create` directly to the base `skill` class and then hookTree it.