### PR TITLE
Add GithubTags mod source

### DIFF
--- a/msu/systems/registry/load.nut
+++ b/msu/systems/registry/load.nut
@@ -9,6 +9,7 @@ includeFile("registry_mod_addon");
 
 ::MSU.System.Registry <- ::MSU.Class.RegistrySystem();
 ::MSU.System.Registry.addNewModSource(::MSU.Class.ModSourceGitHub);
+::MSU.System.Registry.addNewModSource(::MSU.Class.ModSourceGitHubTags);
 ::MSU.System.Registry.addNewModSource(::MSU.Class.ModSourceNexusMods);
 ::MSU.getMod <- function( _modID )
 {

--- a/msu/systems/registry/mod_sources/mod_source.nut
+++ b/msu/systems/registry/mod_sources/mod_source.nut
@@ -2,11 +2,21 @@
 {
 	static ModSourceDomain = null;
 	static Regex = null;
+	static BadURLMessage = "A link must be pointing to a specific mod.";
+	static Icon = null;
 	__URL = null;
 
-	constructor( _url )
+	constructor( _url, _opts = null )
 	{
+		if (this.Regex != null && !this.Regex.match(_url))
+		{
+			::logError(this.BadURLMessage);
+			throw ::MSU.Exception.InvalidValue(_url);
+		}
 		this.__URL = _url;
+		if (_opts != null) {
+			foreach (key, value in _opts) this[key] = value;
+		}
 	}
 
 	function getUpdateURL()
@@ -17,5 +27,9 @@
 	function getURL()
 	{
 		return this.__URL
+	}
+
+	function extractRelease(_data) {
+		return null;
 	}
 }

--- a/msu/systems/registry/mod_sources/mod_source_github.nut
+++ b/msu/systems/registry/mod_sources/mod_source_github.nut
@@ -2,20 +2,16 @@
 {
 	static ModSourceDomain = ::MSU.Class.RegistrySystem.ModSourceDomain.GitHub;
 	static Regex = regexp("https:\\/\\/github\\.com\\/([-\\w]+)\\/([-\\w]+)");
-
-	constructor( _url )
-	{
-		if (!this.Regex.match(_url))
-		{
-			::logError("A GitHub link must be a link to a specific repository, e.g. 'https://github.com/MSUTeam/MSU' Check to make sure there's not an issue with your URL and that it is formatted the same way as the MSU URL.");
-			throw ::MSU.Exception.InvalidValue(_url);
-		}
-		base.constructor(_url);
-	}
+	static BadURLMessage = "A GitHub link must be a link to a specific repository, e.g. 'https://github.com/MSUTeam/MSU' Check to make sure there's not an issue with your URL and that it is formatted the same way as the MSU URL.";
+	static Icon = "github";
 
 	function getUpdateURL()
 	{
 		local capture = this.Regex.capture(this.__URL);
 		return "https://api.github.com/repos/" + ::MSU.regexMatch(capture, this.__URL, 1) + "/" + ::MSU.regexMatch(capture, this.__URL, 2) + "/releases/latest"
+	}
+
+	function extractRelease(_data) {
+		return {Version = _data.tag_name, Changes = _data.body};
 	}
 }

--- a/msu/systems/registry/mod_sources/mod_source_githubtags.nut
+++ b/msu/systems/registry/mod_sources/mod_source_githubtags.nut
@@ -1,0 +1,29 @@
+::MSU.Class.ModSourceGitHubTags <- class extends ::MSU.Class.ModSource
+{
+	static ModSourceDomain = ::MSU.Class.RegistrySystem.ModSourceDomain.GitHubTags;
+	static Regex = regexp(@"https://github.com/([-\w]+)/([-\w]+).*");
+	static BadURLMessage = "A link must point into a Github repository, e.g. 'https://github.com/MSUteam/MSU', or a subtree, e.g. 'https://github.com/Suor/battle-brothers-mods/tree/master/autopilot'.";
+	static Icon = "github";
+	// This is one is set via Mod.Registry.addModSource(..., {Prefix = ...}) -> base.constructor()
+	Prefix = ""
+
+	function getUpdateURL()
+	{
+		local capture = this.Regex.capture(this.__URL);
+		local owner = ::MSU.regexMatch(capture, this.__URL, 1);
+		local repo = ::MSU.regexMatch(capture, this.__URL, 2);
+		return format("https://api.github.com/repos/%s/%s/git/matching-refs/tags/%s?per_page=100",
+			owner, repo, this.Prefix)
+	}
+
+	function extractRelease(_data) {
+		local refPrefix = "refs/tags/" + this.Prefix, maxVersion = "0.0.0";
+		foreach (rec in _data) {
+			local version = rec.ref.slice(refPrefix.len());
+			if (!::MSU.SemVer.isSemVer(version)) continue;
+			if (::MSU.SemVer.compareVersionWithOperator(version, ">", maxVersion))
+				maxVersion = version;
+		}
+		return {Version = maxVersion, Changes = ""};
+	}
+}

--- a/msu/systems/registry/mod_sources/mod_source_nexusmods.nut
+++ b/msu/systems/registry/mod_sources/mod_source_nexusmods.nut
@@ -2,19 +2,6 @@
 {
 	static ModSourceDomain = ::MSU.Class.RegistrySystem.ModSourceDomain.NexusMods;
 	static Regex = regexp("https:\\/\\/www\\.nexusmods\\.com\\/battlebrothers\\/mods\\/(\\d+)");
-
-	constructor( _url )
-	{
-		if (!this.Regex.match(_url))
-		{
-			::logError("A NexusMods link must be a link to a specific mod's main page, e.g. 'https://www.nexusmods.com/battlebrothers/mods/479' Check to make sure there's not an issue with your URL and that it is formatted the same way as the MSU URL.");
-			throw ::MSU.Exception.InvalidValue(_url);
-		}
-		base.constructor(_url);
-	}
-
-	function getUpdateURL()
-	{
-		return null; // not currently supported for nexusmods
-	}
+	static BadURLMessage = "A NexusMods link must be a link to a specific mod's main page, e.g. 'https://www.nexusmods.com/battlebrothers/mods/479' Check to make sure there's not an issue with your URL and that it is formatted the same way as the MSU URL.";
+	static Icon = "nexusmods";
 }

--- a/msu/systems/registry/registry_mod_addon.nut
+++ b/msu/systems/registry/registry_mod_addon.nut
@@ -19,10 +19,11 @@
 		return _domain in this.__ModSources;
 	}
 
-	function addModSource( _domain, _url )
+	function addModSource( _domain, _url, _opts = null )
 	{
 		::MSU.requireString(_url);
-		this.__ModSources[_domain] <- ::MSU.System.Registry.ModSources[_domain](_url);
+		if (_opts != null) ::MSU.requireTable(_opts);
+		this.__ModSources[_domain] <- ::MSU.System.Registry.ModSources[_domain](_url, _opts);
 	}
 
 	function getUpdateSource()

--- a/msu/systems/registry/registry_system.nut
+++ b/msu/systems/registry/registry_system.nut
@@ -3,6 +3,7 @@
 	static ModSources = {};
 	static ModSourceDomain = ::MSU.Class.Enum([
 		"GitHub",
+		"GitHubTags",
 		"NexusMods"
 	]);
 	Mods = null;

--- a/msu/systems/registry/registry_system.nut
+++ b/msu/systems/registry/registry_system.nut
@@ -64,10 +64,14 @@
 
 	function checkIfModVersionsAreNew( _modVersionData )
 	{
+		local modInfos = {};
 		foreach (modID, modData in _modVersionData)
 		{
+			modInfos[modID] <- {};
 			local mod = ::MSU.System.Registry.getMod(modID);
-			local version = modData.tag_name;
+			local release = mod.Registry.getUpdateSource().extractRelease(modData);
+			if (!release) continue;
+			local version = release.Version;
 			if (!::MSU.SemVer.isSemVer(version))
 			{
 				::MSU.Popup.addMessage(format("The version '%s' from the mod %s (%s) isn't using <span style=\"color: lightblue; text-decoration: underline;\" onclick=\"openURL('https://semver.org')\">semantic versioning</span> for its online versions, despite registering to use the MSU update checker. Let the mod author know if you see this error", version,  mod.getName(), modID));
@@ -77,19 +81,21 @@
 			local type = "PATCH";
 			if (::MSU.SemVer.compareMajorVersionWithOperator(version, ">", mod)) type = "MAJOR";
 			else if (::MSU.SemVer.compareMinorVersionWithOperator(version, ">", mod)) type = "MINOR";
-			modData.UpdateInfo <- {
+			modInfos[modID].UpdateInfo <- {
 				name = mod.getName(),
 				currentVersion = mod.getVersionString(),
 				availableVersion = version,
 				updateType = type,
+				changes = release.Changes,
 				sources = {},
 			};
 			foreach (modSource in mod.Registry.__ModSources)
 			{
-				modData.UpdateInfo.sources[::MSU.System.Registry.ModSourceDomain.getKeyForValue(modSource.ModSourceDomain)] <- modSource.getURL();
+				local sourceKey = ::MSU.System.Registry.ModSourceDomain.getKeyForValue(modSource.ModSourceDomain);
+				modInfos[modID].UpdateInfo.sources[sourceKey] <- {URL = modSource.getURL(), icon = modSource.Icon};
 			}
 		}
-		return _modVersionData;
+		return modInfos;
 	}
 
 	function getMod( _modID )

--- a/ui/mods/msu/css/popup.css
+++ b/ui/mods/msu/css/popup.css
@@ -111,8 +111,7 @@
 	float: left;
 }
 
-.msu-mod-info-container .l-github-button,
-.msu-mod-info-container .l-nexusmods-button
+.msu-mod-info-container .l-source-button
 {
 	float: right;
 	width: 3.2rem;

--- a/ui/mods/msu/msu_connection.js
+++ b/ui/mods/msu/msu_connection.js
@@ -126,30 +126,19 @@ MSUConnection.prototype.showModUpdates = function (_modVersionData)
 		var coloredSpan = '<span style="color:red;">' + updateInfo.availableVersion.slice(colorFromIdx) + '</span>';
 		versionRow.append($('<div class="msu-mod-version-info text-font-normal">' + updateInfo.currentVersion + ' => ' + start + coloredSpan + ' (Update Available)</div>'));
 
-		if ("GitHub" in updateInfo.sources)
-		{
-			var githubContainer = $('<div class="l-github-button"/>')
-				.appendTo(versionRow);
-			var githubButton = githubContainer.createImageButton(Path.GFX + "mods/msu/logos/github-32.png", function ()
+		$.each(updateInfo.sources, function (_, _source) {
+			var container = $('<div class="l-source-button"/>').appendTo(versionRow);
+			var button = container.createImageButton(Path.GFX + "mods/msu/logos/" + _source.icon + "-32.png", function ()
 			{
-				openURL(updateInfo.sources.GitHub);
+				openURL(_source.URL);
 			});
-		}
-		if ("NexusMods" in updateInfo.sources)
-		{
-			var nexusModsContainer = $('<div class="l-nexusmods-button"/>')
-				.appendTo(versionRow);
-			nexusModsContainer.createImageButton(Path.GFX + "mods/msu/logos/nexusmods-32.png", function ()
-			{
-				openURL(updateInfo.sources.NexusMods);
-			});
-		}
+		})
 
 		// Add update text
-		if (_modInfo.body.length > 0)
+		if (updateInfo.changes)
 		{
 			var descriptionRow = $('<div class="msu-mod-info-description description-font-normal font-color-description"/>')
-				.html(_modInfo.body.replace(/(?:\r\n|\r|\n)/g, '<br>'))
+				.html(updateInfo.changes.replace(/(?:\r\n|\r|\n)/g, '<br>'))
 				.appendTo(modInfoContainer)
 		}
 		MSU.Popup.addListContent(modInfoContainer)


### PR DESCRIPTION
Usage:

```squirrel
mod.Mod.Registry.addModSource(
    ::MSU.System.Registry.ModSourceDomain.GitHubTags,
    // A link into a subdir here, but repo itself is also allowed
    "https://github.com/Suor/battle-brothers-mods/tree/master/autopilot"
    // tag prefix, for i.e. tag autopilot-new-2.2.0 be 2.2.0 release
    {Prefix = "autopilot-new-"});
mod.Mod.Registry.setUpdateSource(::MSU.System.Registry.ModSourceDomain.GitHubTags);

// Can still add this for icon with a link
mod.Mod.Registry.addModSource(
    ::MSU.System.Registry.ModSourceDomain.NexusMods,
    "https://www.nexusmods.com/battlebrothers/mods/675");
```