### PR TITLE
feat: add unique id to entity that is serialized

### DIFF
--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -1,34 +1,21 @@
 ::MSU.MH.hook("scripts/entity/tactical/entity", function(q) {
-	q.m.UID <- 0;
-
 	q.create <- @(__original) function()
 	{
 		__original();
-		this.m.UID = ::MSU.Utils.generateUID();
+		this.getFlags().set("MSU_UID", ::MSU.Utils.generateUID());
 	}
 
 	q.getUID <- function()
 	{
-		return this.m.UID;
-	}
-
-	q.onSerialize = @(__original) function( _out )
-	{
-		this.m.Flags.set("MSU_UID", this.m.UID);
-		__original(_out);
+		return this.getFlags().get("MSU_UID");
 	}
 
 	q.onDeserialize = @(__original) function( _in )
 	{
 		__original(_in);
-		if (this.getFlags().has("MSU_UID"))
+		if (!this.getFlags().has("MSU_UID"))
 		{
-			this.m.UID = this.getFlags().get("MSU_UID");
-			this.getFlags().remove("MSU_UID");
-		}
-		else
-		{
-			this.m.UID = ::MSU.Utils.generateUID();
+			this.getFlags().set("MSU_UID", ::MSU.Utils.generateUID());
 		}
 	}
 });

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -1,6 +1,12 @@
 ::MSU.MH.hook("scripts/entity/tactical/entity", function(q) {
 	q.m.UID <- 0;
 
+	q.create <- @(__original) function()
+	{
+		__original();
+		this.m.UID = ::MSU.Utils.generateUID();
+	}
+
 	q.getUID <- function()
 	{
 		return this.m.UID;
@@ -19,7 +25,6 @@
 		{
 			this.m.UID = this.getFlags().get("MSU_UID");
 			this.getFlags().remove("MSU_UID");
-			::MSU.Utils.registerUID(this.m.UID);
 		}
 		else
 		{

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -1,0 +1,29 @@
+::MSU.MH.hook("scripts/entity/tactical/entity", function(q) {
+	q.m.UID <- 0;
+
+	q.getUID <- function()
+	{
+		return this.m.UID;
+	}
+
+	q.onSerialize = @(__original) function( _out )
+	{
+		this.m.Flags.set("MSU_UID", this.m.UID);
+		__original(_out);
+	}
+
+	q.onDeserialize = @(__original) function( _in )
+	{
+		__original(_in);
+		if (this.getFlags().has("MSU_UID"))
+		{
+			this.m.UID = this.getFlags().get("MSU_UID");
+			this.getFlags().remove("MSU_UID");
+			::MSU.Utils.registerUID(this.m.UID);
+		}
+		else
+		{
+			this.m.UID = ::MSU.Utils.generateUID();
+		}
+	}
+});

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.getFlags().set("MSU_UID", ::MSU.Serialization.isLoading() ? null : ::MSU.Utils.__generateUID());
+		this.MSU_generateUID();
 	}
 
 	q.getUID <- function()
@@ -13,12 +13,25 @@
 		return this.getFlags().get("MSU_UID");
 	}
 
+	// Private
+	q.MSU_generateUID <- function( _force = false )
+	{
+		if (_force)
+		{
+			this.getFlags().set("MSU_UID", ::MSU.Utils.__generateUID());
+		}
+		else
+		{
+			this.getFlags().set("MSU_UID", ::MSU.Serialization.isLoading() ? null : ::MSU.Utils.__generateUID());
+		}
+	}
+
 	q.onDeserialize = @(__original) function( _in )
 	{
 		__original(_in);
 		if (this.getFlags().get("MSU_UID") == null)
 		{
-			this.getFlags().set("MSU_UID", ::MSU.Utils.__generateUID());
+			this.MSU_generateUID(true);
 		}
 	}
 });

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -2,18 +2,21 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.getFlags().set("MSU_UID", ::MSU.Utils.generateUID());
+		this.getFlags().set("MSU_UID", ::MSU.Serialization.isLoading() ? null : ::MSU.Utils.generateUID());
 	}
 
 	q.getUID <- function()
 	{
+		if (::MSU.Serialization.isLoading())
+			throw "trying to get UID during deserialization";
+
 		return this.getFlags().get("MSU_UID");
 	}
 
 	q.onDeserialize = @(__original) function( _in )
 	{
 		__original(_in);
-		if (!this.getFlags().has("MSU_UID"))
+		if (this.getFlags().get("MSU_UID") == null)
 		{
 			this.getFlags().set("MSU_UID", ::MSU.Utils.generateUID());
 		}

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -2,7 +2,10 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.MSU_generateUID();
+		if (!::MSU.Serialization.isLoading())
+		{
+			this.MSU_generateUID();
+		}
 	}
 
 	q.getUID <- function()
@@ -13,25 +16,17 @@
 		return this.getFlags().get("MSU_UID");
 	}
 
-	// Private
-	q.MSU_generateUID <- function( _force = false )
+	q.MSU_generateUID <- function()
 	{
-		if (_force)
-		{
-			this.getFlags().set("MSU_UID", ::MSU.Utils.__generateUID());
-		}
-		else
-		{
-			this.getFlags().set("MSU_UID", ::MSU.Serialization.isLoading() ? null : ::MSU.Utils.__generateUID());
-		}
+		this.getFlags().set("MSU_UID", ::MSU.Utils.__generateUID());
 	}
 
 	q.onDeserialize = @(__original) function( _in )
 	{
 		__original(_in);
-		if (this.getFlags().get("MSU_UID") == null)
+		if (!this.getFlags().has("MSU_UID"))
 		{
-			this.MSU_generateUID(true);
+			this.MSU_generateUID();
 		}
 	}
 });

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -18,6 +18,9 @@
 
 	q.MSU_generateUID <- function()
 	{
+		if (this.getFlags().has("MSU_UID"))
+			throw "trying to generate UID for entity that already has one";
+
 		this.getFlags().set("MSU_UID", ::MSU.Utils.__generateUID());
 	}
 

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -1,5 +1,5 @@
 ::MSU.MH.hook("scripts/entity/tactical/entity", function(q) {
-	q.create <- @(__original) function()
+	q.create = @(__original) function()
 	{
 		__original();
 		this.getFlags().set("MSU_UID", ::MSU.Utils.generateUID());

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -2,7 +2,7 @@
 	q.create = @(__original) function()
 	{
 		__original();
-		this.getFlags().set("MSU_UID", ::MSU.Serialization.isLoading() ? null : ::MSU.Utils.generateUID());
+		this.getFlags().set("MSU_UID", ::MSU.Serialization.isLoading() ? null : ::MSU.Utils.__generateUID());
 	}
 
 	q.getUID <- function()
@@ -18,7 +18,7 @@
 		__original(_in);
 		if (this.getFlags().get("MSU_UID") == null)
 		{
-			this.getFlags().set("MSU_UID", ::MSU.Utils.generateUID());
+			this.getFlags().set("MSU_UID", ::MSU.Utils.__generateUID());
 		}
 	}
 });

--- a/msu/hooks/states/world_state.nut
+++ b/msu/hooks/states/world_state.nut
@@ -293,6 +293,7 @@
 	{
 		::MSU.System.ModSettings.flagSerialize(_out);
 		::World.Flags.set("MSU.LastDayMorningEventCalled", ::World.Assets.getLastDayMorningEventCalled());
+		::World.Flags.set("MSU_LastUID", ::MSU.Utils.UID);
 		__original(_out);
 		::MSU.System.Serialization.clearFlags();
 	}
@@ -307,6 +308,10 @@
 		else
 		{
 			::World.Assets.setLastDayMorningEventCalled(::World.getTime().Days);
+		}
+		if (::World.Flags.has("MSU_LastUID"))
+		{
+			::MSU.Utils.UID = ::World.Flags.get("MSU_LastUID");
 		}
 		::MSU.System.ModSettings.flagDeserialize(_in);
 		::MSU.System.Serialization.clearFlags();

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -1,4 +1,5 @@
 ::MSU.Utils <- {
+	UIDs <- {},
 	DataType = {
 		Integer = 0,
 		Float = 1,
@@ -242,6 +243,34 @@
 			local timePctText = format("<span style='color:%s;'>%i%% %s</span>", color, ::Math.abs(100 * diff / times[0].TotalTime), diff < 0 ? "faster" : "slower");
 			::logInfo(format("<span>%s: %s ms (Total: %s ms) -- %s</span>", _functions[i][0] + "", timePerIterationText, totalTimeText, i == 0 ? "base time" : timePctText));
 		}
+	}
+
+	function generateUID()
+	{
+		local function createUID()
+		{
+			local ret = 0;
+			for (local i = 1; i <= 100000; i *= 10)
+			{
+				ret += i * ::Math.rand(0, 9);
+			}
+			return ret;
+		}
+
+		local uid = createUID();
+		while (uid in ::MSU.Utils.UIDs)
+		{
+			uid = createUID();
+		}
+
+		this.registerUID(uid);
+
+		return uid;
+	}
+
+	function registerUID( _id )
+	{
+		::MSU.Utils.UIDs[_id] <- false;
 	}
 
 	// Deprecated - use ::MSU.AI.addBehavior instead

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -1,5 +1,5 @@
 ::MSU.Utils <- {
-	UIDs <- -2147483648,
+	UIDs = -2147483648,
 	DataType = {
 		Integer = 0,
 		Float = 1,

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -1,5 +1,5 @@
 ::MSU.Utils <- {
-	UIDs <- {},
+	UIDs <- -2147483648,
 	DataType = {
 		Integer = 0,
 		Float = 1,
@@ -247,30 +247,7 @@
 
 	function generateUID()
 	{
-		local function createUID()
-		{
-			local ret = 0;
-			for (local i = 1; i <= 100000; i *= 10)
-			{
-				ret += i * ::Math.rand(0, 9);
-			}
-			return ret;
-		}
-
-		local uid = createUID();
-		while (uid in ::MSU.Utils.UIDs)
-		{
-			uid = createUID();
-		}
-
-		this.registerUID(uid);
-
-		return uid;
-	}
-
-	function registerUID( _id )
-	{
-		::MSU.Utils.UIDs[_id] <- false;
+		return ::MSU.Utils.UID++;
 	}
 
 	// Deprecated - use ::MSU.AI.addBehavior instead

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -1,5 +1,5 @@
 ::MSU.Utils <- {
-	UIDs = -2147483648,
+	UID = -2147483648,
 	DataType = {
 		Integer = 0,
 		Float = 1,

--- a/msu/utils/utils.nut
+++ b/msu/utils/utils.nut
@@ -245,7 +245,8 @@
 		}
 	}
 
-	function generateUID()
+	// Private
+	function __generateUID()
 	{
 		return ::MSU.Utils.UID++;
 	}


### PR DESCRIPTION
Vanilla has a `getID()` for entities but that ID is changed on every game load. This PR adds a Unique ID to every entity that is preserved across game save/load. This can be useful for a number of things.