### PR TITLE
fix: switch to hookTree to call onQueryTooltip

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -440,6 +440,18 @@
 });
 
 ::MSU.QueueBucket.VeryLate.push(function() {
+	::MSU.MH.hookTree("scripts/skills/skill", function(q) {
+		q.getTooltip = @(__original) function()
+		{
+			local ret = __original();
+			if (!::MSU.isNull(this.getContainer()))
+			{
+				this.getContainer().onQueryTooltip(this, ret);
+			}
+			return ret;
+		}
+	});
+
 	::MSU.MH.hook("scripts/skills/skill", function(q) {
 		foreach (func in ::MSU.Skills.PreviewApplicableFunctions)
 		{

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -444,7 +444,7 @@
 		q.getTooltip = @(__original) function()
 		{
 			local ret = __original();
-			if (!::MSU.isNull(this.getContainer()))
+			if (!::MSU.isNull(this.getContainer()) && !::MSU.isNull(this.getContainer().getActor()))
 			{
 				this.getContainer().onQueryTooltip(this, ret);
 			}

--- a/msu/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/msu/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -9,31 +9,6 @@
 		return ret;
 	}
 
-	q.general_querySkillTooltipData = @(__original) function( _entityId, _skillId )
-	{
-		local ret = __original(_entityId, _skillId);
-
-		if (ret != null)
-		{
-			local skill = ::Tactical.getEntityByID(_entityId).getSkills().getSkillByID(_skillId);
-			skill.getContainer().onQueryTooltip(skill, ret);
-		}
-
-		return ret;
-	}
-
-	q.general_queryStatusEffectTooltipData = @(__original) function( _entityId, _statusEffectId )
-	{
-		local ret = __original(_entityId, _statusEffectId);
-		if (ret != null)
-		{
-			local statusEffect = ::Tactical.getEntityByID(_entityId).getSkills().getSkillByID(_statusEffectId);
-			statusEffect.getContainer().onQueryTooltip(statusEffect, ret);
-		}
-
-		return ret;
-	}
-
 	q.onQueryMSUTooltipData <- function( _data )
 	{
 		return ::MSU.System.Tooltips.getTooltip(_data.modId, _data.elementId).getUIData(_data);


### PR DESCRIPTION
Instead of manually calling via query functions inside tooltip_events. The query functions are only used when querying the tooltip via the UI so it misses cases where the tooltip of a skill is manually fetched.

In particular this fixes the situation where in the Nested Tooltips Framework, the nested tooltip of a skill is generated in code by calling `getTooltip` on the skill and this doesn't trigger the `onQueryTooltip`.