### PR TITLE
feat: add new onAnyBroHired event for skills

### DIFF
--- a/msu/hooks/entity/tactical/player.nut
+++ b/msu/hooks/entity/tactical/player.nut
@@ -27,6 +27,16 @@
 		this.m.LevelUpsSpent++;
 	}
 
+	q.onHired = @(__original) function()
+	{
+		__original();
+
+		foreach (bro in ::World.getPlayerRoster().getAll())
+		{
+			bro.getSkills().onAnyBroHired(this);
+		}
+	}
+
 	q.onSerialize = @(__original) function( _out )
 	{
 		this.getFlags().set("LevelUpsSpent", this.m.LevelUpsSpent);

--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -437,6 +437,12 @@
 
 		return _tooltip;
 	}
+
+	/// This event is triggered once for every skill of every character in the player roster after the onHired event of a player class is triggered
+	/// @param _bro is a reference to the player object whose onHired event was triggered
+	q.onAnyBroHired <- function( _bro )
+	{
+	}
 });
 
 ::MSU.QueueBucket.VeryLate.push(function() {

--- a/msu/hooks/skills/skill_container.nut
+++ b/msu/hooks/skills/skill_container.nut
@@ -538,4 +538,13 @@
 
 		return ret;
 	}
+
+	/// This event is triggered once for every other character in the player roster after the onHired event of a player class is triggered
+	/// @param _bro is a reference to the player object whose onHired event was triggered
+	q.onAnyBroHired <- function( _bro )
+	{
+		this.callSkillsFunction("onAnyBroHired", [
+			_bro
+		]);
+	}
 });


### PR DESCRIPTION
`onHired` is an event already present in Vanilla but only in the `player.nut` and for origins.
Skills however can't react to the hiring of someone.

~~### This PR proposes two new events for skills:~~
```
// This event is triggered once for every skill of a player character directly after the onHired event of that player class is triggered
function onHired()

// This event is triggered once for every skill of every other character in the player roster after the onHired event of a player class is triggered~~
function onOtherPlayerHired( _otherCharacter )
```
### This PR proposes one new events for skills:
```
/// This event is triggered once for every skill of every character in the player roster after the onHired event of a player class is triggered
/// @param _bro is a refernce to the player object whose onHired event was triggered
function onAnyBroHired <- function( _bro )
```

## Possible Use Cases
~~### onHired~~
### onAnyBroHired
- Certain backgrounds can apply mood buff/debuff on hiring, depending on what other backgrounds are already present in the player party
- Some traits might act as a wildcard/unrevelaed at first (despite trying out) and only transform into a real trait after hiring

~~### onOtherPlayerHired~~
- Certain backgrounds might cause a brother to get a positive/negative mood when you hire a certain background
- Certain backgrounds/perks could grant a bonus to every new recruit (e.g. free perk/stats)