### PR TITLE
fix: only fire skill execution events if skill actually executed

### DIFF
--- a/msu/hooks/skills/skill.nut
+++ b/msu/hooks/skills/skill.nut
@@ -17,6 +17,8 @@
 });
 
 ::MSU.MH.hook("scripts/skills/skill", function(q) {
+	q.m.MSU_IsUsingSkill <- false;
+	q.m.MSU_IsUsingSkillForFree <- false;
 	q.m.AIBehaviorID <- null;
 	q.m.DamageType <- null;
 	q.m.ItemActionOrder <- ::Const.ItemActionOrder.Any;
@@ -306,18 +308,10 @@
 
 	q.use = @(__original) function( _targetTile, _forFree = false )
 	{
-		// Save the container as a local variable because some skills delete
-		// themselves during use (e.g. Reload Bolt) causing this.m.Container
-		// to point to null.
-		local container = this.m.Container;
-		local targetEntity = _targetTile.IsOccupiedByActor ? _targetTile.getEntity() : null;
-
-		container.onBeforeAnySkillExecuted(this, _targetTile, targetEntity, _forFree);
-
+		this.m.MSU_IsUsingSkill = true;
+		this.m.MSU_IsUsingSkillForFree = _forFree;
 		local ret = __original(_targetTile, _forFree);
-
-		container.onAnySkillExecuted(this, _targetTile, targetEntity, _forFree);
-
+		this.m.MSU_IsUsingSkill = false;
 		return ret;
 	}
 
@@ -440,6 +434,30 @@
 });
 
 ::MSU.QueueBucket.VeryLate.push(function() {
+	::MSU.MH.hookTree("scripts/skills/skill", function(q) {
+		q.onUse = @(__original) function( _user, _targetTile )
+		{
+			// Save the container as a local variable because some skills delete
+			// themselves during use (e.g. Reload Bolt) causing this.m.Container
+			// to point to null.
+			local container = this.getContainer();
+			local targetEntity = _targetTile.IsOccupiedByActor ? _targetTile.getEntity() : null;
+			if (this.m.MSU_IsUsingSkill)
+			{
+				container.onBeforeAnySkillExecuted(this, _targetTile, targetEntity, this.m.MSU_IsUsingSkillForFree);
+			}
+
+			local ret = __original(_user, _targetTile);
+
+			if (this.m.MSU_IsUsingSkill)
+			{
+				container.onAnySkillExecuted(this, _targetTile, targetEntity, this.m.MSU_IsUsingSkillForFree);
+			}
+
+			return ret;
+		}
+	});
+
 	::MSU.MH.hook("scripts/skills/skill", function(q) {
 		foreach (func in ::MSU.Skills.PreviewApplicableFunctions)
 		{


### PR DESCRIPTION
Vanilla `use` function has checks built in which may cause it to return early and not actually execute the skill. Hooking onUse ensures that we only fire it when the skill is being executed, however in this case we still need a flag to switch from `use` as `onUse` can be called manually as well.

This will require us to update our documentation as it currently says that these events are fired before and after `use`. So now we'd have to say they fire before and after `onUse`.