### PR TITLE
Feat getKeybind and capitalized key combinations

### DIFF
--- a/msu/systems/keybinds/abstract_keybind.nut
+++ b/msu/systems/keybinds/abstract_keybind.nut
@@ -39,6 +39,12 @@
 		return this.KeyCombinations.reduce(@(_a, _b) _a + "/" + _b);
 	}
 
+	function getKeyCombinationsCapitalized()
+	{
+		if (this.KeyCombinations.len() == 0) return "";
+		return this.KeyCombinations.reduce(@(_a, _b) ::MSU.String.capitalizeFirst(_a) + "/" + ::MSU.String.capitalizeFirst(_b));
+	}
+
 	function getRawKeyCombinations()
 	{
 		return this.KeyCombinations;

--- a/msu/systems/keybinds/keybinds_mod_addon.nut
+++ b/msu/systems/keybinds/keybinds_mod_addon.nut
@@ -21,6 +21,11 @@
 		return ::MSU.System.Keybinds.add(keybind);
 	}
 
+	function getKeybind( _id )
+	{
+		return ::MSU.System.Keybinds.KeybindsByMod[this.Mod.getID()][_id];
+	}
+
 	function isKeybindPressed( _id )
 	{
 		return ::MSU.System.Keybinds.isKeybindPressed(this.Mod.getID(), _id);


### PR DESCRIPTION
- add `getKeybind` function to keybind mods addon
- add `_capitalizeFirst` as optional parameter to `getKeyCombinations` of `abstract_keybind` which, if true, returns first letter capitalized keybind string.