### PR TITLE
Optimize getActors functions

### DIFF
--- a/msu/hooks/entity/tactical/tactical_entity_manager.nut
+++ b/msu/hooks/entity/tactical/tactical_entity_manager.nut
@@ -35,6 +35,27 @@
 		}
 		return ret;
 	}
+
+	q.getAdjacentActors <- function( _tile )
+	{
+		if (_tile.ID == 0)
+		{
+			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
+			throw ::MSU.Exception.InvalidValue(_tile);
+		}
+
+		local ret = [];
+		for (local i = 0; i < 6; i++)
+		{
+			if (!_tile.hasNextTile(i))
+				continue;
+
+			local nextTile = _tile.getNextTile(i);
+			if (nextTile.IsOccupiedByActor)
+				ret.push(nextTile.getEntity());
+		}
+		return ret;
+	}
 	
 	q.getAlliedActors <- function( _faction, _tile = null, _distance = null, _atDistance = false )
 	{

--- a/msu/hooks/entity/tactical/tactical_entity_manager.nut
+++ b/msu/hooks/entity/tactical/tactical_entity_manager.nut
@@ -65,6 +65,14 @@
 			throw ::MSU.Exception.InvalidValue(_tile);
 		}
 
+		if (_distance == 1)
+		{
+			local ret = this.getAdjacentActors(_tile);
+			if (!_atDistance && _tile.IsOccupiedByActor)
+				ret.push(_tile.getEntity());
+			return ret.filter(@(_, _a) _a.isAlliedWith(_faction));
+		}
+
 		return this.getActorsByFunction(function(_actor) {
 			if (!_actor.isAlliedWith(_faction)) return false;
 			if (_tile != null)
@@ -83,6 +91,14 @@
 		{
 			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
 			throw ::MSU.Exception.InvalidValue(_tile);
+		}
+
+		if (_distance == 1)
+		{
+			local ret = this.getAdjacentActors(_tile);
+			if (!_atDistance && _tile.IsOccupiedByActor)
+				ret.push(_tile.getEntity());
+			return ret.filter(@(_, _a) !_a.isAlliedWith(_faction));
 		}
 
 		return this.getActorsByFunction(function(_actor) {
@@ -108,6 +124,14 @@
 			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
 			throw ::MSU.Exception.InvalidValue(_tile);
 		}
+
+		if (_distance == 1)
+		{
+			local ret = this.getAdjacentActors(_tile);
+			if (!_atDistance && _tile.IsOccupiedByActor)
+				ret.push(_tile.getEntity());
+			return ret.filter(@(_, _a) _a.getFaction() == _faction);
+		}
 				
 		local actors = this.getInstancesOfFaction(_faction);
 		local ret = [];
@@ -127,6 +151,14 @@
 		{
 			::logError("The ID of _tile is 0 which means that the actor this tile was fetched from is not placed on map.");
 			throw ::MSU.Exception.InvalidValue(_tile);
+		}
+
+		if (_distance == 1)
+		{
+			local ret = this.getAdjacentActors(_tile);
+			if (!_atDistance && _tile.IsOccupiedByActor)
+				ret.push(_tile.getEntity());
+			return ret.filter(@(_, _a) _a.isAlliedWith(_faction) && _a.getFaction() != _faction);
 		}
 
 		return this.getActorsByFunction(function(_actor) {


### PR DESCRIPTION
Instead of the other PR of adding actors within distance functions (#344) which has overlap with the vanilla `::Tactical.queryActorsInRange`, causing us to not include that PR, I present to you the other important part of that PR which _should_ be included:

perf: optimize getActors functions for the case of 1 distance

Instead of iterating over all the actors on the battlefield and measuring their distance to `_tile`, we only iterate over the adjacent 6 tiles. Getting adjacent actors is a very widely used thing in mods and occurs inside often repeating functions e.g. onUpdate so it is good to optimize it.

