### PR TITLE
fix: allow null in writeString of serde emulator

### DIFF
--- a/msu/systems/serialization/serde_emulator.nut
+++ b/msu/systems/serialization/serde_emulator.nut
@@ -58,7 +58,8 @@
 	static __WriteFields = {
 		function writeString( _string )
 		{
-			::MSU.requireString(_string);
+			if (_string != null)
+				::MSU.requireString(_string);
 			this.__writeData(_string, ::MSU.Serialization.DataType.String);
 		}
 


### PR DESCRIPTION
When serializing a SerializationData, outside a regular save process of the game, the MetaData contains things such as Name, Filename etc. which are null but are stored in the SerializationEmulator with `writeString`. This does NOT throw any errors if the  SerializationData is serialized during a regular game save cycle using the native `_out` object instead of a SerializationEmulator. However, with the emulator it throws an exception due to this requirement. In order to match the behavior of the vanilla native object, we should allow nulls.

This PR is on top of the other PR which fixes exceptions in the write integer cases: #412.