### PR TITLE
feat: add ability to get entity by UID globally

### DIFF
--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -22,6 +22,12 @@
 			throw "trying to generate UID for entity that already has one";
 
 		this.getFlags().set("MSU_UID", ::MSU.Utils.__generateUID());
+		this.MSU_addToUIDMap();
+	}
+
+	q.MSU_addToUIDMap <- function()
+	{
+		::MSU.entityUIDMap[this.getFlags().get("MSU_UID")] <- this.weakref();
 	}
 
 	q.onDeserialize = @(__original) function( _in )
@@ -30,6 +36,10 @@
 		if (!this.getFlags().has("MSU_UID"))
 		{
 			this.MSU_generateUID();
+		}
+		else
+		{
+			this.MSU_addToUIDMap();
 		}
 	}
 });

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -27,7 +27,7 @@
 
 	q.MSU_addToUIDMap <- function()
 	{
-		::MSU.entityUIDMap[this.getFlags().get("MSU_UID")] <- this.weakref();
+		::MSU.entityUIDMap[this.getFlags().get("MSU_UID")] <- ::MSU.asWeakTableRef(this);
 	}
 
 	q.onDeserialize = @(__original) function( _in )

--- a/msu/hooks/entity/tactical/entity.nut
+++ b/msu/hooks/entity/tactical/entity.nut
@@ -22,12 +22,7 @@
 			throw "trying to generate UID for entity that already has one";
 
 		this.getFlags().set("MSU_UID", ::MSU.Utils.__generateUID());
-		this.MSU_addToUIDMap();
-	}
-
-	q.MSU_addToUIDMap <- function()
-	{
-		::MSU.entityUIDMap[this.getFlags().get("MSU_UID")] <- ::MSU.asWeakTableRef(this);
+		::MSU.__addToUIDMap(this);
 	}
 
 	q.onDeserialize = @(__original) function( _in )
@@ -39,7 +34,7 @@
 		}
 		else
 		{
-			this.MSU_addToUIDMap();
+			::MSU.__addToUIDMap(this);
 		}
 	}
 });

--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -189,8 +189,12 @@
 	}
 }
 
-::MSU.entityUIDMap <- {};
+::MSU.__entityUIDMap <- {};
+::MSU.__addToUIDMap <- function( _entity )
+{
+	::MSU.__entityUIDMap[_entity.getFlags().get("MSU_UID")] <- ::MSU.asWeakTableRef(_entity);
+}
 ::MSU.getEntityByUID <- function( _uid )
 {
-	return _uid in ::MSU.entityUIDMap ? ::MSU.entityUIDMap[_uid].get() : null;
+	return _uid in ::MSU.__entityUIDMap ? ::MSU.__entityUIDMap[_uid].get() : null;
 }

--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -192,5 +192,5 @@
 ::MSU.entityUIDMap <- {};
 ::MSU.getEntityByUID <- function( _uid )
 {
-	return _uid in ::MSU.entityUIDMap ? ::MSU.entityUIDMap[_uid] : null;
+	return _uid in ::MSU.entityUIDMap ? ::MSU.entityUIDMap[_uid].get() : null;
 }

--- a/msu/utils/globals.nut
+++ b/msu/utils/globals.nut
@@ -188,3 +188,9 @@
 			return _a == _b;
 	}
 }
+
+::MSU.entityUIDMap <- {};
+::MSU.getEntityByUID <- function( _uid )
+{
+	return _uid in ::MSU.entityUIDMap ? ::MSU.entityUIDMap[_uid] : null;
+}


### PR DESCRIPTION
Is it fine in `::MSU.getEntityByUID`? I decided to not put it in `::Tactical` to avoid potential name collisions with other mods (or future vanilla updates).