### PR TITLE
feat: add function for stable sorting arrays

### DIFF
--- a/msu/utils/array.nut
+++ b/msu/utils/array.nut
@@ -79,6 +79,32 @@
 		}
 	}
 
+	// Unlike squirrel array.sort, this preserves the order of equal members and also returns the array at the end.
+	// Uses Insertion Sort algorithm. Merge Sort is slow in squirrel even for large arrays (even len 1000 array is ~1000% slower than Insertion Sort).
+	// A hybrid of Insertion and Merge is also considerably slower than pure Insertion (~700% slower for 1000 len array).
+	function stableSort( _array, _compareFunc = null )
+	{
+		if (_array.len() <= 1)
+			return _array;
+
+		local len = _array.len();
+		for (local i = 1; i < len; i++)
+		{
+			local key = _array[i];
+			local j = i - 1;
+
+			while (j >= 0 && (_compareFunc ? _compareFunc(_array[j], key) > 0 : _array[j] > key))
+			{
+				_array[j + 1] = _array[j];
+				j--;
+			}
+
+			_array[j + 1] = key;
+		}
+
+		return _array;
+	}
+
 	function sortDescending( _array, _member = null )
 	{
 		if (_member == null)


### PR DESCRIPTION
This function seems important because we had a really mysterious bug in Reforged caused by a very sneaky bug in Dynamic Spawns Framework which wasn't really a bug but a consequence of the fact that the squirrel `array.sort` does not preserve order for equal elements. It was causing units of equal cost in a unit block to become randomly ordered and this was not very obvious at all.

We need a function that sorts in a stable way, at least for use cases where the order is important.