### PR TITLE
feat: add ::MSU.Math.clamp function

### DIFF
--- a/msu/utils/math.nut
+++ b/msu/utils/math.nut
@@ -1,4 +1,16 @@
 ::MSU.Math <- {
+	// Clamps an integer or float _value to be within [_min, _max] range
+	// throw InvalidValue exception when _min is greater than _max
+	function clamp(_value, _min, _max)
+	{
+		if (_min > _max)
+		{
+			::logError("_min must be less than or equal to _max");
+			throw ::MSU.Exception.InvalidValue(_min);
+		}
+		return _value < _min ? _min : (_value > _max ? _max : _value);
+	}
+
 	// returns log2 of _num, floored (as an int)
 	function log2int( _num )
 	{


### PR DESCRIPTION
This common math function is missing in the squirrel ::Math table.
It is very useful to improve readability, as currently we need to implement clamping by writing something like this:
`return ::Math.max(0, ::Math.min(100, _foo));`

That could now be written by 
`return ::MSU.Math.clamp(_foo, 0, 100);`
And the intent would be clear right away; not half-way into reading the line (well, for bigger lines)