### PR TITLE
feat: add tables to facilitate translation of weapontypes and categories

### DIFF
--- a/msu/hooks/config/items.nut
+++ b/msu/hooks/config/items.nut
@@ -77,6 +77,37 @@ foreach (itemType in ::Const.Items.ItemType)
 	Musical = 32768
 };
 
+// Map WeaponTypes to relevant strings from weapon.m.Categories.
+// Is used during automatic assignment of weapontypes to weapons.
+// Translators should push strings to the relevant weaponType here.
+::Const.Items.WeaponTypeCategoriesStrings <- {
+	[::Const.Items.WeaponType.Axe] = ["Axe"],
+	[::Const.Items.WeaponType.Bow] = ["Bow"],
+	[::Const.Items.WeaponType.Cleaver] = ["Cleaver"],
+	[::Const.Items.WeaponType.Crossbow] = ["Crossbow"],
+	[::Const.Items.WeaponType.Dagger] = ["Dagger"],
+	[::Const.Items.WeaponType.Firearm] = ["Firearm"],
+	[::Const.Items.WeaponType.Flail] = ["Flail"],
+	[::Const.Items.WeaponType.Hammer] = ["Hammer"],
+	[::Const.Items.WeaponType.Mace] = ["Mace"],
+	[::Const.Items.WeaponType.Polearm] = ["Polearm"],
+	[::Const.Items.WeaponType.Sling] = ["Sling"],
+	[::Const.Items.WeaponType.Spear] = ["Spear"],
+	[::Const.Items.WeaponType.Sword] = ["Sword"],
+	[::Const.Items.WeaponType.Staff] = ["Staff"],
+	[::Const.Items.WeaponType.Throwing] = ["Throwing"],
+	[::Const.Items.WeaponType.Musical] = ["Musical"]
+};
+
+// Map OneHanded and TwoHanded to relevant strings from weapon.m.Categories
+// Is used during weapon.buildCategoriesFromWeaponType.
+// Translators should push strings to the relevant handed-ness here.
+// The last index string is always used to build the categories string.
+::Const.Items.WeaponHandedCategoriesStrings <- {
+	OneHanded = ["One-Handed"],
+	TwoHanded = ["Two-Handed"]
+};
+
 ::Const.Items.WeaponTypeName <- [
 	"No Weapon Type",
 	"Axe",
@@ -127,5 +158,6 @@ foreach (itemType in ::Const.Items.ItemType)
 		_weaponTypeName = _weaponType;
 	}
 
+	::Const.Items.WeaponTypeCategoriesStrings[::Const.Items.WeaponType[_weaponType]] <- [_weaponType];
 	::Const.Items.WeaponTypeName.push(_weaponTypeName);
 }

--- a/msu/hooks/config/items.nut
+++ b/msu/hooks/config/items.nut
@@ -158,6 +158,6 @@ foreach (itemType in ::Const.Items.ItemType)
 		_weaponTypeName = _weaponType;
 	}
 
-	::Const.Items.WeaponTypeCategoriesStrings[::Const.Items.WeaponType[_weaponType]] <- [_weaponType];
+	::Const.Items.WeaponTypeCategoriesStrings[::Const.Items.WeaponType[_weaponType]] <- [_weaponTypeName];
 	::Const.Items.WeaponTypeName.push(_weaponTypeName);
 }

--- a/msu/hooks/config/items.nut
+++ b/msu/hooks/config/items.nut
@@ -113,16 +113,46 @@ foreach (itemType in ::Const.Items.ItemType)
 // Translators should push strings to the relevant weaponType here.
 // Key = WeaponType
 // Value = array of strings from weapon.m.Categories that should match to this weapon type
-::Const.Items.WeaponTypeCategoriesStrings <- {};
-foreach (w in ::Const.Items.WeaponType)
+
+// Translators Note: DO NOT OVERWRITE THIS TABLE, instead push your strings to each array e.g.
+// ::Const.Items.WeaponTypesCategoriesStrings.Axe.push("TranslatedAxe");
+::Const.Items.WeaponTypeCategoriesStrings <- {
+	[::Const.Items.WeaponType.None] = ["None", "No Weapon Type"]
+	[::Const.Items.WeaponType.Axe] = ["Axe"],
+	[::Const.Items.WeaponType.Bow] = ["Bow"],
+	[::Const.Items.WeaponType.Cleaver] = ["Cleaver"],
+	[::Const.Items.WeaponType.Crossbow] = ["Crossbow"],
+	[::Const.Items.WeaponType.Dagger] = ["Dagger"],
+	[::Const.Items.WeaponType.Firearm] = ["Firearm"],
+	[::Const.Items.WeaponType.Flail] = ["Flail"],
+	[::Const.Items.WeaponType.Hammer] = ["Hammer"],
+	[::Const.Items.WeaponType.Mace] = ["Mace"],
+	[::Const.Items.WeaponType.Polearm] = ["Polearm"],
+	[::Const.Items.WeaponType.Sling] = ["Sling"],
+	[::Const.Items.WeaponType.Spear] = ["Spear"],
+	[::Const.Items.WeaponType.Sword] = ["Sword"],
+	[::Const.Items.WeaponType.Staff] = ["Staff"],
+	[::Const.Items.WeaponType.Throwing] = ["Throwing", "Throwing Weapon"],
+	[::Const.Items.WeaponType.Musical] = ["Musical", "Musical Instrument"]
+};
+local arr = ::Const.Items.WeaponTypeCategoriesStrings;
+foreach (k, w in ::Const.Items.WeaponType)
 {
-	::Const.Items.WeaponTypeCategoriesStrings[w] <- [::Const.Items.getWeaponTypeName(w)];
+	if (arr.find(k) == null)
+		arr.push(k);
+
+	local name = ::Const.Items.getWeaponTypeName(w);
+	if (arr.find(name) == null)
+		arr.push(name)
 }
 
 // Map OneHanded and TwoHanded to relevant strings from weapon.m.Categories
 // Is used during weapon.buildCategoriesFromWeaponType.
 // Translators should push strings to the relevant handed-ness here.
 // The last index string is always used to build the categories string.
+
+// Translators Note: DO NOT OVERWRITE THIS TABLE, instead push your strings to each array e.g.
+// ::Const.Items.WeaponHandedCategoriesStrings.OneHanded.push("One-HandedTranslation");
 ::Const.Items.WeaponHandedCategoriesStrings <- {
 	OneHanded = ["One-Handed"],
 	TwoHanded = ["Two-Handed"]

--- a/msu/hooks/config/items.nut
+++ b/msu/hooks/config/items.nut
@@ -77,37 +77,6 @@ foreach (itemType in ::Const.Items.ItemType)
 	Musical = 32768
 };
 
-// Map WeaponTypes to relevant strings from weapon.m.Categories.
-// Is used during automatic assignment of weapontypes to weapons.
-// Translators should push strings to the relevant weaponType here.
-::Const.Items.WeaponTypeCategoriesStrings <- {
-	[::Const.Items.WeaponType.Axe] = ["Axe"],
-	[::Const.Items.WeaponType.Bow] = ["Bow"],
-	[::Const.Items.WeaponType.Cleaver] = ["Cleaver"],
-	[::Const.Items.WeaponType.Crossbow] = ["Crossbow"],
-	[::Const.Items.WeaponType.Dagger] = ["Dagger"],
-	[::Const.Items.WeaponType.Firearm] = ["Firearm"],
-	[::Const.Items.WeaponType.Flail] = ["Flail"],
-	[::Const.Items.WeaponType.Hammer] = ["Hammer"],
-	[::Const.Items.WeaponType.Mace] = ["Mace"],
-	[::Const.Items.WeaponType.Polearm] = ["Polearm"],
-	[::Const.Items.WeaponType.Sling] = ["Sling"],
-	[::Const.Items.WeaponType.Spear] = ["Spear"],
-	[::Const.Items.WeaponType.Sword] = ["Sword"],
-	[::Const.Items.WeaponType.Staff] = ["Staff"],
-	[::Const.Items.WeaponType.Throwing] = ["Throwing"],
-	[::Const.Items.WeaponType.Musical] = ["Musical"]
-};
-
-// Map OneHanded and TwoHanded to relevant strings from weapon.m.Categories
-// Is used during weapon.buildCategoriesFromWeaponType.
-// Translators should push strings to the relevant handed-ness here.
-// The last index string is always used to build the categories string.
-::Const.Items.WeaponHandedCategoriesStrings <- {
-	OneHanded = ["One-Handed"],
-	TwoHanded = ["Two-Handed"]
-};
-
 ::Const.Items.WeaponTypeName <- [
 	"No Weapon Type",
 	"Axe",
@@ -127,6 +96,27 @@ foreach (itemType in ::Const.Items.ItemType)
 	"Throwing Weapon",
 	"Musical Instrument"
 ];
+
+// Map WeaponTypes to relevant strings from weapon.m.Categories.
+// Is used during automatic assignment of weapontypes to weapons.
+// Translators should push strings to the relevant weaponType here.
+
+// Key = WeaponType
+// Value = array of strings from weapon.m.Categories that should match to this weapon type
+::Const.Items.WeaponTypeCategoriesStrings <- {};
+foreach (w in ::Const.Items.WeaponType)
+{
+	::Const.Items.WeaponTypeCategoriesStrings[w] <- [::Const.Items.getWeaponTypeName(w)];
+}
+
+// Map OneHanded and TwoHanded to relevant strings from weapon.m.Categories
+// Is used during weapon.buildCategoriesFromWeaponType.
+// Translators should push strings to the relevant handed-ness here.
+// The last index string is always used to build the categories string.
+::Const.Items.WeaponHandedCategoriesStrings <- {
+	OneHanded = ["One-Handed"],
+	TwoHanded = ["Two-Handed"]
+};
 
 ::Const.Items.getWeaponTypeName <- function( _weaponType )
 {

--- a/msu/hooks/config/items.nut
+++ b/msu/hooks/config/items.nut
@@ -97,10 +97,20 @@ foreach (itemType in ::Const.Items.ItemType)
 	"Musical Instrument"
 ];
 
+::Const.Items.getWeaponTypeName <- function( _weaponType )
+{
+	local idx = ::MSU.Math.log2int(_weaponType) + 1;
+	if (idx < ::Const.Items.WeaponTypeName.len())
+	{
+		return ::Const.Items.WeaponTypeName[idx];
+	}
+
+	throw ::MSU.Exception.KeyNotFound(_weaponType);
+}
+
 // Map WeaponTypes to relevant strings from weapon.m.Categories.
 // Is used during automatic assignment of weapontypes to weapons.
 // Translators should push strings to the relevant weaponType here.
-
 // Key = WeaponType
 // Value = array of strings from weapon.m.Categories that should match to this weapon type
 ::Const.Items.WeaponTypeCategoriesStrings <- {};
@@ -117,17 +127,6 @@ foreach (w in ::Const.Items.WeaponType)
 	OneHanded = ["One-Handed"],
 	TwoHanded = ["Two-Handed"]
 };
-
-::Const.Items.getWeaponTypeName <- function( _weaponType )
-{
-	local idx = ::MSU.Math.log2int(_weaponType) + 1;
-	if (idx < ::Const.Items.WeaponTypeName.len())
-	{
-		return ::Const.Items.WeaponTypeName[idx];
-	}
-
-	throw ::MSU.Exception.KeyNotFound(_weaponType);
-}
 
 ::Const.Items.addNewWeaponType <- function( _weaponType, _weaponTypeName = "" )
 {

--- a/msu/hooks/items/weapons/weapon.nut
+++ b/msu/hooks/items/weapons/weapon.nut
@@ -54,29 +54,41 @@
 			return;
 		}
 
-		foreach (k, w in ::Const.Items.WeaponType)
+		foreach (weaponType, strings in ::Const.Items.WeaponTypeCategoriesStrings)
 		{
-			if (categories.find(k) != null)
+			foreach (str in strings)
 			{
-				this.m.WeaponType = this.m.WeaponType | w;
+				if (categories.find(str) != null)
+				{
+					this.m.WeaponType = this.m.WeaponType | weaponType;
+					break;
+				}
 			}
 		}
 
-		if (categories.find("One-Handed") != null && !this.isItemType(::Const.Items.ItemType.OneHanded))
+		foreach (str in ::Const.Items.WeaponHandedCategoriesStrings.OneHanded)
 		{
-			this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.OneHanded;
-			if (this.isItemType(::Const.Items.ItemType.TwoHanded))
+			if (categories.find(str) != null && !this.isItemType(::Const.Items.ItemType.OneHanded))
 			{
-				this.m.ItemType -= ::Const.Items.ItemType.TwoHanded;
+				this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.OneHanded;
+				if (this.isItemType(::Const.Items.ItemType.TwoHanded))
+				{
+					this.m.ItemType -= ::Const.Items.ItemType.TwoHanded;
+				}
+				break;
 			}
 		}
 
-		if (categories.find("Two-Handed") != null && !this.isItemType(::Const.Items.ItemType.TwoHanded))
+		foreach (str in ::Const.Items.WeaponHandedCategoriesStrings.TwoHanded)
 		{
-			this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.TwoHanded;
-			if (this.isItemType(::Const.Items.ItemType.OneHanded))
+			if (categories.find(str) != null && !this.isItemType(::Const.Items.ItemType.TwoHanded))
 			{
-				this.m.ItemType -= ::Const.Items.ItemType.OneHanded;
+				this.m.ItemType = this.m.ItemType | ::Const.Items.ItemType.TwoHanded;
+				if (this.isItemType(::Const.Items.ItemType.OneHanded))
+				{
+					this.m.ItemType -= ::Const.Items.ItemType.OneHanded;
+				}
+				break;
 			}
 		}
 	}
@@ -144,13 +156,15 @@
 
 		if (this.m.Categories != "") this.m.Categories = this.m.Categories.slice(0, -1) + ", ";
 
+		// We always use the last entry that was pushed to the strings so translators just
+		// have to push it there and it works.
 		if (this.isItemType(::Const.Items.ItemType.OneHanded))
 		{
-			this.m.Categories += "One-Handed";
+			this.m.Categories += ::Const.Items.WeaponHandedCategoriesStrings.OneHanded.top();
 		}
 		else if (this.isItemType(::Const.Items.ItemType.TwoHanded))
 		{
-			this.m.Categories += "Two-Handed";
+			this.m.Categories += ::Const.Items.WeaponHandedCategoriesStrings.TwoHanded.top();
 		}
 	}
 


### PR DESCRIPTION
The issue is that because the Key inside ::Const.Items.WeaponType is what is used to check for strings inside weapon.m.Categories to assign weapontype or vice versa, it creates a hurdle for translators as translated strings are not matched and therefore automatic weapontype assignment fails.

We change this by decoupling those strings and adding new tables where relevant strings can be pushed by translators.