### PR TITLE
refactor: fix barbute and sallet plainVariant for older vanilla only

### DIFF
--- a/msu/hooks/items/helmets/barbute_helmet.nut
+++ b/msu/hooks/items/helmets/barbute_helmet.nut
@@ -1,8 +1,11 @@
-::MSU.MH.hook("scripts/items/helmets/barbute_helmet", function(q) {
-	// VANIILLAFIX: https://battlebrothersgame.com/forums/topic/wrong-variant-in-setplainvariant-of-sallet_helmet/
-	// https://steamcommunity.com/app/365360/discussions/1/4408543140360563731/
-	q.setPlainVariant = @() function()
-	{
-		this.setVariant(158);
-	}
-});
+if (::Hooks.getMod("vanilla").getVersion() <= ::Hooks.SQClass.ModVersion("1.5.0-15"))
+{
+	::MSU.MH.hook("scripts/items/helmets/barbute_helmet", function(q) {
+		// VANIILLAFIX: https://battlebrothersgame.com/forums/topic/wrong-variant-in-setplainvariant-of-sallet_helmet/
+		// https://steamcommunity.com/app/365360/discussions/1/4408543140360563731/
+		q.setPlainVariant = @() function()
+		{
+			this.setVariant(158);
+		}
+	});
+}

--- a/msu/hooks/items/helmets/sallet_helmet.nut
+++ b/msu/hooks/items/helmets/sallet_helmet.nut
@@ -1,8 +1,11 @@
-::MSU.MH.hook("scripts/items/helmets/sallet_helmet", function(q) {
-	// VANIILLAFIX: https://battlebrothersgame.com/forums/topic/wrong-variant-in-setplainvariant-of-sallet_helmet/
-	// https://steamcommunity.com/app/365360/discussions/1/4408543140360563731/
-	q.setPlainVariant = @() function()
-	{
-		this.setVariant(163);
-	}
+if (::Hooks.getMod("vanilla").getVersion() <= ::Hooks.SQClass.ModVersion("1.5.0-15"))
+{
+	::MSU.MH.hook("scripts/items/helmets/sallet_helmet", function(q) {
+		// VANIILLAFIX: https://battlebrothersgame.com/forums/topic/wrong-variant-in-setplainvariant-of-sallet_helmet/
+		// https://steamcommunity.com/app/365360/discussions/1/4408543140360563731/
+		q.setPlainVariant = @() function()
+		{
+			this.setVariant(163);
+		}
+	});
 });


### PR DESCRIPTION
Because this has been fixed in vanilla 1.5.1.4.