### PR TITLE
feat: return removed item when removing from weighted container

### DIFF
--- a/msu/classes/weighted_container.nut
+++ b/msu/classes/weighted_container.nut
@@ -110,7 +110,8 @@
 	{
 		if (this.Table[_item] < 0) delete this.Forced[_item];
 		else this.Total -= this.Table[_item];
-		delete this.Table[_item];
+
+		return delete this.Table[_item];
 	}
 
 	function contains( _item )


### PR DESCRIPTION
Seems like a pretty straightforward feature to have and is consistent with `array.remove` and `delete` for table slots.

Allows to do the following to roll items from a container while removing them so they cannot be rolled more than once:
```squirrel
local item1 = weightedContainer.remove(weightedContainer.roll());
local item2 = weightedContainer.remove(weightedContainer.roll());
```
instead of
```squirrel
local item1 = weightedContainer.roll();
weightedContainer.remove(item1);
local item2 = weightedContainer.roll();
```

