### PR TITLE
fix: flip IsSaving and IsLoading during all BB scripts serde functions

### DIFF
--- a/msu/utils/serialization.nut
+++ b/msu/utils/serialization.nut
@@ -16,8 +16,8 @@
 		"Array",
 		"SerializationData"
 	]),
-	IsSaving = false, // Is flipped during world_state.saveCampaign
-	IsLoading = false, // Is flipped during world_state.loadCampaign
+	IsSaving = false, // Is flipped during world_state.saveCampaign and from within all BB scripts onSerialize via VeryLate hook
+	IsLoading = false, // Is flipped during world_state.loadCampaign and from within all BB scripts onDeserialize via Verylate hook
 
 	function isSaving()
 	{

--- a/scripts/!mods_preload/msu.nut
+++ b/scripts/!mods_preload/msu.nut
@@ -15,6 +15,37 @@
 	{
 		func();
 	}
+	// People can use MSU SerDe Emulators to save/load BB tables outside the regular save/load process of the game.
+	// These onSerialize and onDeserialize functions of the BB tables may contain or may affect logic that is
+	// dependent on knowing whether the game is being loaded or saved. This means that said logic should not trigger
+	// while the object is being serialized/deserialized. Therefore, we need to flip the IsSaving and IsLoading
+	// to true during ser/de of all BB tables.
+	foreach (file in ::IO.enumerateFiles("scripts/"))
+	{
+		::MSU.MH.hook(file, function(q) {
+			if (q.contains("onSerialize"))
+			{
+				q.onSerialize = @(__original) function( _out )
+				{
+					local wasSaving = ::MSU.Serialization.IsSaving;
+					::MSU.Serialization.IsSaving = true;
+					__original(_out);
+					::MSU.Serialization.IsSaving = wasSaving;
+				}
+			}
+
+			if (q.contains("onDeserialize"))
+			{
+				q.onDeserialize = @(__original) function( _in )
+				{
+					local wasLoading = ::MSU.Serialization.IsLoading;
+					::MSU.Serialization.IsLoading = true;
+					__original(_in);
+					::MSU.Serialization.IsLoading = wasLoading;
+				}
+			}
+		});
+	}
 	::MSU.QueueBucket.VeryLate.clear();
 }, ::Hooks.QueueBucket.VeryLate);
 


### PR DESCRIPTION
People can use MSU SerDe Emulators to save/load BB tables outside the regular save/load process of the game. These onSerialize and onDeserialize functions of the BB tables may contain or may affect logic that is dependent on knowing whether the game is being loaded or saved. This means that said logic should not trigger while the object is being serialized/deserialized. Therefore, we need to flip the IsSaving and IsLoading to true during ser/de of all BB tables.