### PR TITLE
fix: not calling onUnequip when removing items from bag

### DIFF
--- a/msu/hooks/items/item_container.nut
+++ b/msu/hooks/items/item_container.nut
@@ -76,9 +76,35 @@
 		return ret;
 	}
 
+	// Call our skill_container.onUnequip function
 	q.unequip = @(__original) function( _item )
 	{
-		if (_item != null && _item != -1 && _item.getCurrentSlotType() != ::Const.ItemSlot.None && _item.getCurrentSlotType() != ::Const.ItemSlot.Bag && !::MSU.isNull(this.m.Actor) && this.m.Actor.isAlive())
+		if (_item != null && _item != -1 && _item.getCurrentSlotType() != ::Const.ItemSlot.None && (_item.getCurrentSlotType() != ::Const.ItemSlot.Bag || _item.getSlotType() == ::Const.ItemSlot.Bag) && !::MSU.isNull(this.m.Actor) && this.m.Actor.isAlive())
+		{
+			foreach (item in this.m.Items[_item.getSlotType()])
+			{
+				if (item == _item)
+				{
+					this.m.Actor.getSkills().onUnequip(_item);
+					break;
+				}
+			}
+		}
+
+		// VanillaFix: https://steamcommunity.com/app/365360/discussions/1/684112192552961717/
+		// `item_container.unequip` not properly removing bagged items while `item_container.equip` puts them in the bag.
+		if (_item.getSlotType() == ::Const.ItemSlot.Bag)
+		{
+			return this.removeFromBag(_item);
+		}
+
+		return __original(_item);
+	}
+
+	// Call our skill_container.onUnequip function
+	q.removeFromBag = @(__original) function( _item )
+	{
+		if (_item.getCurrentSlotType() == this.Const.ItemSlot.Bag && _item.getSlotType() == ::Const.ItemSlot.Bag)
 		{
 			foreach (item in this.m.Items[_item.getSlotType()])
 			{
@@ -91,5 +117,17 @@
 		}
 
 		return __original(_item);
+	}
+
+	// Call our skill_container.onUnequip function
+	q.removeFromBagSlot = @(__original) function( _slot )
+	{
+		local item = this.m.Items[::Const.ItemSlot.Bag][_slot];
+		if (item != null && item.getSlotType() == ::Const.ItemSlot.Bag)
+		{
+			this.m.Actor.getSkills().onUnequip(item);
+		}
+
+		return __original(_slot);
 	}
 });


### PR DESCRIPTION
Vanilla places items which have SlotType ItemSlot.Bag in the Bag slot and during item_container.equip. Therefore, we are properly calling onEquip for such items (e.g. bandages). However, vanilla does NOT remove these items from the bag during item_container.unequip. So we are not calling onUnequip for them. This leads to unexpected behavior and runaway changes if a mod applies some changes during onEquip for such items and expects to revert said changes during onUnequip but the onUnequip never runs.

We also fix the vanilla issue of item_container.unequip not handling the removal of bagged items. For this the bug report can be seen here: https://steamcommunity.com/app/365360/discussions/1/684112192552961717/