### PR TITLE
fix: trying to reset fields on potentially unadded skills from weapon

### DIFF
--- a/msu/hooks/items/shields/shield.nut
+++ b/msu/hooks/items/shields/shield.nut
@@ -2,6 +2,13 @@
 	q.addSkill = @(__original) function( _skill )
 	{
 		__original(_skill);
+
+		// If the skill wasn't actually added to the container for some reason
+		// (e.g. adding non-stacking skill that already exists in the container)
+		// then we bail out.
+		if (::MSU.isNull(_skill.getContainer()))
+			return;
+
 		if (_skill.isType(::Const.SkillType.Active))
 		{
 			// We reset the FatigueCost so any modifications to it from other skills is reverted

--- a/msu/hooks/items/weapons/weapon.nut
+++ b/msu/hooks/items/weapons/weapon.nut
@@ -22,7 +22,14 @@
 
 	q.addSkill = @(__original) function( _skill )
 	{
-		local ret = __original(_skill);
+		__original(_skill);
+
+		// If the skill wasn't actually added to the container for some reason
+		// (e.g. adding non-stacking skill that already exists in the container)
+		// then we bail out.
+		if (::MSU.isNull(_skill.getContainer()))
+			return;
+
 		if (::MSU.isIn("AdditionalAccuracy", _skill.m, true))
 		{
 			_skill.resetField("AdditionalAccuracy");
@@ -41,7 +48,6 @@
 			_skill.setBaseValue("FatigueCost", fatCost);
 			this.getContainer().getActor().getSkills().update();
 		}
-		return ret;
 	}
 
 	q.buildWeaponTypeFromCategories <- function()


### PR DESCRIPTION
Non-stacking skills are not added to a skill_container that already has a skill with that ID. So if a weapon tries to add such a skill, it will not get added to the container. Therefore, we add a guard statement and return early in this case.