### PR TITLE
fix: msu serde complains due to null strings in metadata emulator

### DIFF
--- a/msu/systems/serialization/metadata_emulator.nut
+++ b/msu/systems/serialization/metadata_emulator.nut
@@ -13,6 +13,13 @@
 	{
 		this.Data = {};
 		this.Version = ::Const.Serialization.Version;
+		// Have to initialize these to empty strings otherwise MSU SerDe
+		// complains about null being written as string on the very first
+		// serialization using MSU SerDe during a new campaign.
+		this.Name = "";
+		this.ModificationDate = "";
+		this.CreationDate = "";
+		this.FileName = "";
 	}
 
 	// this would ideally be an alternative static constructor


### PR DESCRIPTION
In a new campaign, the Name, ModificationData, CreationDate and FileName are all null in the real metadata. This causes no issues in vanilla as it accepts nulls into `writeString`. But this means that any SerDe done using MSU SerDe emulators on a new campaign will throw complaints about null being stored into String data container.