### PR TITLE
fix: remove IsSpent field declaration from perk_quick_hands hook

### DIFF
--- a/msu/hooks/skills/perks/perk_quick_hands.nut
+++ b/msu/hooks/skills/perks/perk_quick_hands.nut
@@ -1,6 +1,4 @@
 ::MSU.MH.hook("scripts/skills/perks/perk_quick_hands", function(q) {
-	q.m.IsSpent <- false;
-
 	q.create = @(__original) function()
 	{
 		__original();


### PR DESCRIPTION
## Problem

BB **1.5.2.2** added `IsSpent` natively to `scripts/skills/perks/perk_quick_hands`. MSU's hook declares the same field with the `<-` (new slot) operator, causing a hard error on startup:

> Mod mod_msu is adding a new field IsSpent to bb class scripts/skills/perks/perk_quick_hands, but that field already exists in scripts/skills/perks/perk_quick_hands which is either the class itself or an ancestor

## Fix

Remove `q.m.IsSpent <- false;` from `msu/hooks/skills/perks/perk_quick_hands.nut`. The method overrides (`isHidden`, `getItemActionCost`, `onPayForItemAction`, `onTurnStart`) all reference `this.m.IsSpent` and continue to compile against vanilla's native field.

## Testing

Confirmed fix resolves the startup error on BB 1.5.2.2 with MSU 1.8.0.

## ⚠️ Deeper compatibility concern — needs maintainer review

Analysis of the BB 1.5.2.2 bytecode (`data_001.dat`) reveals that vanilla introduced more than just the `IsSpent` field. Two new identifiers appear in the compiled scripts:

- `perk_quick_hands.cnut` — new method: **`onSpend`**
- `scripts/items/item_container.cnut` — calls **`onSpend`** and checks **`isSpent`** (lowercase, likely a method)

This suggests vanilla now has a **native item-action spending system** in `item_container` that calls `onSpend` on perks and checks `isSpent()` for availability — a parallel system to MSU's `getItemActionCost` / `onPayForItemAction` / `isHidden` pattern.

Both systems share the `IsSpent` field. The interaction is unclear from bytecode alone:
- Do both systems fire on item swap, making MSU's logic redundant?
- Does vanilla's `isSpent()` method exist natively on `perk_quick_hands`, or does it fall through to something else?
- Does MSU's empty `onUpdate` / `onCombatStarted` stub suppress any new vanilla behavior tied to the native spending system?

This fix silences the startup error (which is the right minimal change), but the broader compatibility of MSU's six method overrides against vanilla's reworked quick_hands warrants a closer look by someone with access to decompiled source.

Closes #494