### PR TITLE
Add labelInTitle option to SliderSetting

### DIFF
--- a/msu/systems/mod_settings/elements/slider_setting.nut
+++ b/msu/systems/mod_settings/elements/slider_setting.nut
@@ -2,6 +2,7 @@
 {
 	Values = null;
 	Labels = null;
+	LabelInTitle = false;
 	static Type = "Slider";
 
 	constructor( _id, _value, _values, _labels = null, _name = null, _description = null )
@@ -22,11 +23,17 @@
 		this.Labels = _labels;
 	}
 
+	function setLabelInTitle( _value )
+	{
+		this.LabelInTitle = _value;
+	}
+
 	function getUIData( _flags = [] )
 	{
 		local ret = base.getUIData(_flags);
 		ret.values <- this.Values;
 		ret.labels <- this.Labels;
+		ret.labelInTitle <- this.LabelInTitle;
 		return ret;
 	}
 

--- a/ui/mods/msu/mod_settings/slider_setting.js
+++ b/ui/mods/msu/mod_settings/slider_setting.js
@@ -1,6 +1,13 @@
 var SliderSetting = function (_mod, _page, _setting, _parentDiv)
 {
 	RangeSetting.call(this, _mod, _page, _setting, _parentDiv);
+
+	if (_setting.labelInTitle)
+	{
+		this.label.detach();
+		this.label.css({ position: 'static', top: '', left: '', 'margin-left': 'auto' });
+		this.titleContainer.append(this.label);
+	}
 };
 
 // Inheritance in JS


### PR DESCRIPTION
Any labels longer then several symbols overlap with a control to the right (if slider is in the left column). This is fine for most cases, where labels is a number or a single short word, but lacks flexibility.

This PR adds an optional `labelInTitle` mode to `SliderSetting`. When enabled, the slider's current-value label is rendered in the setting's title row (right-aligned) instead of next to the slider track.

## API

```squirrel
local setting = ::MSU.Class.SliderSetting(...);
setting.setLabelInTitle(true);
```

I tried passing it to constructor, it works but cumbersome without named params, which squirrel lacks and MSU doesn't emulate. Settled on accessor. 

## Changes

- `slider_setting.nut`: new `LabelInTitle` field (default `false`), `setLabelInTitle(_value)` setter, and `labelInTitle` passed through `getUIData()`.
- `slider_setting.js`: when `labelInTitle` is set, detach the label and append it to the `titleContainer`.

Default behavior is unchanged (`LabelInTitle = false`).
