### PR TITLE
fix: weapon type detection from cateogories not using the correct names

### DIFF
--- a/msu/hooks/items/weapons/weapon.nut
+++ b/msu/hooks/items/weapons/weapon.nut
@@ -62,7 +62,7 @@
 
 		foreach (k, w in ::Const.Items.WeaponType)
 		{
-			if (categories.find(k) != null)
+			if (categories.find(::Const.Items.getWeaponTypeName(w)) != null)
 			{
 				this.m.WeaponType = this.m.WeaponType | w;
 			}


### PR DESCRIPTION
Vanilla uses the weapon names from `::Const.Items.WeaponTypeName` in `this.m.Categories`
The only reason that this code worked is, because the keys from `::Const.Items.WeaponType` happen to be an exact subset of their respective full names

The current implementation (before this proposed fix) could cause complications, if a mod chooses to 
- rename some/all of the weapon types in `WeaponTypeName` (e.g. translation)
- create new items, filling out their `this.m.Cateogires` with those new weapon type terms

Then MSU would not be able to detect the weapon types anymore, because it looks for the old, english keys from `WeaponType`, when it should scan for their human-readable names from `WeaponTypeName`
