### PR TITLE
fix: mod setting lock lost when loading a save

### DIFF
--- a/msu/systems/mod_settings/abstract_setting.nut
+++ b/msu/systems/mod_settings/abstract_setting.nut
@@ -171,9 +171,12 @@
 
 	function __setFromSerializationTable( _table )
 	{
+		// A lock put on by mod code describes the current mod set, not the save, so outlive it
+		local locked = this.isLocked(), lockReason = this.getLockReason();
 		this.unlock();
 		this.set(_table.Value, true, false, true, true);
-		if (_table.Locked) this.lock(_table.LockReason);
+		if (locked) this.lock(lockReason);
+		else if (_table.Locked) this.lock(_table.LockReason);
 	}
 
 	function getSerDeFlag()


### PR DESCRIPTION
A lock a mod puts on a setting at load time now survives a campaign saved before that lock existed.